### PR TITLE
Add logger implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <modules>
         <module>sf-fx-runtime-java-cloudevent</module>
         <module>sf-fx-runtime-java-sdk-impl-v0</module>
+        <module>sf-fx-runtime-java-logger</module>
         <module>sf-fx-runtime-java-runtime</module>
     </modules>
 

--- a/sf-fx-runtime-java-logger/pom.xml
+++ b/sf-fx-runtime-java-logger/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>sf-fx-runtime-java</artifactId>
+    <groupId>com.salesforce.functions</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>sf-fx-runtime-java-logger</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/Constants.java
+++ b/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/Constants.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+public class Constants {
+    public static final String LOGGER_NAME_SEGMENT_DELIMITER = ".";
+}

--- a/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/DefaultLoggingFormatter.java
+++ b/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/DefaultLoggingFormatter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.slf4j.MDC;
+import org.slf4j.event.Level;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DefaultLoggingFormatter implements LoggingFormatter {
+    private final Clock clock;
+
+    public DefaultLoggingFormatter(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public String format(String loggerName, Level level, String message) {
+        String invocationId = MDC.get("function-invocation-id");
+        String localDateTimeString = LocalDateTime.now(clock).format(DATE_TIME_FORMATTER);
+
+        return String.format(
+                FORMAT_STRING,
+                localDateTimeString,
+                level.toString(),
+                invocationId,
+                Utils.shortenLoggerName(loggerName, 36),
+                message
+        );
+    }
+
+    private static final String FORMAT_STRING = "%s %-5s [INVOCATION %s] %s - %s\n";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+}

--- a/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLogger.java
+++ b/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLogger.java
@@ -26,35 +26,37 @@ public class FunctionsLogger implements Logger {
 
     private void log(Level level, String message) {
         if (isLevelEnabled(level)) {
-            System.out.print(formatter.format(name, level, message));
+            log(level, message, (Throwable) null);
         }
     }
 
     private void log(Level level, String s, Object o) {
         if (isLevelEnabled(level)) {
             FormattingTuple formattingTuple = MessageFormatter.format(s, o);
-            log(level, formattingTuple.getMessage());
+            log(level, formattingTuple.getMessage(), formattingTuple.getThrowable());
         }
     }
 
     private void log(Level level, String s, Object o, Object o1) {
         if (isLevelEnabled(level)) {
             FormattingTuple formattingTuple = MessageFormatter.format(s, o, o1);
-            log(level, formattingTuple.getMessage());
+            log(level, formattingTuple.getMessage(), formattingTuple.getThrowable());
         }
     }
 
     private void log(Level level, String s, Object... objects) {
         if (isLevelEnabled(level)) {
             FormattingTuple formattingTuple = MessageFormatter.arrayFormat(s, objects);
-            log(level, formattingTuple.getMessage());
+            log(level, formattingTuple.getMessage(), formattingTuple.getThrowable());
         }
     }
 
     private void log(Level level, String s, Throwable throwable) {
         if (isLevelEnabled(level)) {
-            FormattingTuple formattingTuple = MessageFormatter.format(s, throwable);
-            log(level, formattingTuple.getMessage());
+            System.out.print(formatter.format(name, level, s));
+            if (throwable != null) {
+                throwable.printStackTrace();
+            }
         }
     }
 

--- a/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLogger.java
+++ b/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLogger.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.event.Level;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+
+public class FunctionsLogger implements Logger {
+    private final String name;
+    private final Level loggerLevel;
+    private final LoggingFormatter formatter;
+
+    public FunctionsLogger(String name, Level loggerLevel, LoggingFormatter formatter) {
+        this.name = name;
+        this.loggerLevel = loggerLevel;
+        this.formatter = formatter;
+    }
+
+    private void log(Level level, String message) {
+        if (isLevelEnabled(level)) {
+            System.out.print(formatter.format(name, level, message));
+        }
+    }
+
+    private void log(Level level, String s, Object o) {
+        if (isLevelEnabled(level)) {
+            FormattingTuple formattingTuple = MessageFormatter.format(s, o);
+            log(level, formattingTuple.getMessage());
+        }
+    }
+
+    private void log(Level level, String s, Object o, Object o1) {
+        if (isLevelEnabled(level)) {
+            FormattingTuple formattingTuple = MessageFormatter.format(s, o, o1);
+            log(level, formattingTuple.getMessage());
+        }
+    }
+
+    private void log(Level level, String s, Object... objects) {
+        if (isLevelEnabled(level)) {
+            FormattingTuple formattingTuple = MessageFormatter.arrayFormat(s, objects);
+            log(level, formattingTuple.getMessage());
+        }
+    }
+
+    private void log(Level level, String s, Throwable throwable) {
+        if (isLevelEnabled(level)) {
+            FormattingTuple formattingTuple = MessageFormatter.format(s, throwable);
+            log(level, formattingTuple.getMessage());
+        }
+    }
+
+    private boolean isLevelEnabled(Level level) {
+        return level.toInt() >= loggerLevel.toInt();
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return isLevelEnabled(Level.TRACE);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return isLevelEnabled(Level.DEBUG);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return isLevelEnabled(Level.INFO);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return isLevelEnabled(Level.WARN);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return isLevelEnabled(Level.ERROR);
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker marker) {
+        return isTraceEnabled();
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker marker) {
+        return isDebugEnabled();
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker marker) {
+        return isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker marker) {
+        return isWarnEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker marker) {
+        return isErrorEnabled();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void trace(String s) {
+        log(Level.TRACE, s);
+    }
+
+    @Override
+    public void trace(String s, Object o) {
+        log(Level.TRACE, s, o);
+    }
+
+    @Override
+    public void trace(String s, Object o, Object o1) {
+        log(Level.TRACE, s, o, o1);
+    }
+
+    @Override
+    public void trace(String s, Object... objects) {
+        log(Level.TRACE, s, objects);
+    }
+
+    @Override
+    public void trace(String s, Throwable throwable) {
+        log(Level.TRACE, s, throwable);
+    }
+
+    @Override
+    public void trace(Marker marker, String s) {
+        trace(s);
+    }
+
+    @Override
+    public void trace(Marker marker, String s, Object o) {
+        trace(s, o);
+    }
+
+    @Override
+    public void trace(Marker marker, String s, Object o, Object o1) {
+        trace(s, o, o1);
+    }
+
+    @Override
+    public void trace(Marker marker, String s, Object... objects) {
+        trace(s, objects);
+    }
+
+    @Override
+    public void trace(Marker marker, String s, Throwable throwable) {
+        trace(s, throwable);
+    }
+
+    @Override
+    public void debug(String s) {
+        log(Level.DEBUG, s);
+    }
+
+    @Override
+    public void debug(String s, Object o) {
+        log(Level.DEBUG, s, o);
+    }
+
+    @Override
+    public void debug(String s, Object o, Object o1) {
+        log(Level.DEBUG, s, o, o1);
+    }
+
+    @Override
+    public void debug(String s, Object... objects) {
+        log(Level.DEBUG, s, objects);
+    }
+
+    @Override
+    public void debug(String s, Throwable throwable) {
+        log(Level.DEBUG, s, throwable);
+    }
+
+    @Override
+    public void debug(Marker marker, String s) {
+        debug(s);
+    }
+
+    @Override
+    public void debug(Marker marker, String s, Object o) {
+        debug(s, o);
+    }
+
+    @Override
+    public void debug(Marker marker, String s, Object o, Object o1) {
+        debug(s, o, o1);
+    }
+
+    @Override
+    public void debug(Marker marker, String s, Object... objects) {
+        debug(s, objects);
+    }
+
+    @Override
+    public void debug(Marker marker, String s, Throwable throwable) {
+        debug(s, throwable);
+    }
+
+    @Override
+    public void info(String s) {
+        log(Level.INFO, s);
+    }
+
+    @Override
+    public void info(String s, Object o) {
+        log(Level.INFO, s, o);
+    }
+
+    @Override
+    public void info(String s, Object o, Object o1) {
+        log(Level.INFO, s, o, o1);
+    }
+
+    @Override
+    public void info(String s, Object... objects) {
+        log(Level.INFO, s, objects);
+    }
+
+    @Override
+    public void info(String s, Throwable throwable) {
+        log(Level.INFO, s, throwable);
+    }
+
+    @Override
+    public void info(Marker marker, String s) {
+        info(s);
+    }
+
+    @Override
+    public void info(Marker marker, String s, Object o) {
+        info(s, o);
+    }
+
+    @Override
+    public void info(Marker marker, String s, Object o, Object o1) {
+        info(s, o, o1);
+    }
+
+    @Override
+    public void info(Marker marker, String s, Object... objects) {
+        info(s, objects);
+    }
+
+    @Override
+    public void info(Marker marker, String s, Throwable throwable) {
+        info(s, throwable);
+    }
+
+    @Override
+    public void warn(String s) {
+        log(Level.WARN, s);
+    }
+
+    @Override
+    public void warn(String s, Object o) {
+        log(Level.WARN, s, o);
+    }
+
+    @Override
+    public void warn(String s, Object o, Object o1) {
+        log(Level.WARN, s, o, o1);
+    }
+
+    @Override
+    public void warn(String s, Object... objects) {
+        log(Level.WARN, s, objects);
+    }
+
+    @Override
+    public void warn(String s, Throwable throwable) {
+        log(Level.WARN, s, throwable);
+    }
+
+    @Override
+    public void warn(Marker marker, String s) {
+        warn(s);
+    }
+
+    @Override
+    public void warn(Marker marker, String s, Object o) {
+        warn(s, o);
+    }
+
+    @Override
+    public void warn(Marker marker, String s, Object o, Object o1) {
+        warn(s, o, o1);
+    }
+
+    @Override
+    public void warn(Marker marker, String s, Object... objects) {
+        warn(s, objects);
+    }
+
+    @Override
+    public void warn(Marker marker, String s, Throwable throwable) {
+        warn(s, throwable);
+    }
+
+    @Override
+    public void error(String s) {
+        log(Level.ERROR, s);
+    }
+
+    @Override
+    public void error(String s, Object o) {
+        log(Level.ERROR, s, o);
+    }
+
+    @Override
+    public void error(String s, Object o, Object o1) {
+        log(Level.ERROR, s, o, o1);
+    }
+
+    @Override
+    public void error(String s, Object... objects) {
+        log(Level.ERROR, s, objects);
+    }
+
+    @Override
+    public void error(String s, Throwable throwable) {
+        log(Level.ERROR, s, throwable);
+    }
+
+    @Override
+    public void error(Marker marker, String s) {
+        error(s);
+    }
+
+    @Override
+    public void error(Marker marker, String s, Object o) {
+        error(s, o);
+    }
+
+    @Override
+    public void error(Marker marker, String s, Object o, Object o1) {
+        error(s, o, o1);
+    }
+
+    @Override
+    public void error(Marker marker, String s, Object... objects) {
+        error(s, objects);
+    }
+
+    @Override
+    public void error(Marker marker, String s, Throwable throwable) {
+        error(s, throwable);
+    }
+}

--- a/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLoggerFactory.java
+++ b/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLoggerFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import java.time.Clock;
+
+public class FunctionsLoggerFactory implements ILoggerFactory {
+    private final LoggingConfiguration loggerConfiguration;
+    private final LoggingFormatter loggingFormatter;
+
+    public FunctionsLoggerFactory() {
+        loggerConfiguration = LoggingConfigurator.configureFromEnvironment(System.getenv());
+        loggingFormatter = new DefaultLoggingFormatter(Clock.systemDefaultZone());
+    }
+
+    @Override
+    public Logger getLogger(String name) {
+        Level logLevel = loggerConfiguration.getLogLevelForLoggerName(name);
+        return new FunctionsLogger(name, logLevel, loggingFormatter);
+    }
+}

--- a/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/LoggingConfiguration.java
+++ b/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/LoggingConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.slf4j.event.Level;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static com.salesforce.functions.jvm.runtime.logger.Constants.LOGGER_NAME_SEGMENT_DELIMITER;
+
+public class LoggingConfiguration {
+    private final Level rootLevel;
+    private final Map<String, Level> logLevelByLoggerNames;
+
+    public LoggingConfiguration(Level rootLevel, Map<String, Level> logLevelByLoggerNames) {
+        this.rootLevel = rootLevel;
+        this.logLevelByLoggerNames = Collections.unmodifiableMap(new HashMap<>(logLevelByLoggerNames));
+    }
+
+    public Level getRootLogLevel() {
+        return rootLevel;
+    }
+
+    public Level getLogLevelForLoggerName(String loggerName) {
+        String[] segments = loggerName.split(Pattern.quote(LOGGER_NAME_SEGMENT_DELIMITER));
+
+        for (int i = loggerName.length() - 1; i > 0; i--) {
+            String subPath = String.join(LOGGER_NAME_SEGMENT_DELIMITER, Arrays.copyOfRange(segments, 0, i));
+
+            Level logLevel = logLevelByLoggerNames.get(subPath);
+            if (logLevel != null) {
+                return logLevel;
+            }
+        }
+
+        return rootLevel;
+    }
+}

--- a/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/LoggingConfigurator.java
+++ b/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/LoggingConfigurator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.slf4j.event.Level;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static com.salesforce.functions.jvm.runtime.logger.Constants.LOGGER_NAME_SEGMENT_DELIMITER;
+
+public class LoggingConfigurator {
+
+    public static LoggingConfiguration configureFromEnvironment(Map<String, String> environment) {
+        Map<String, Level> logLevels = new HashMap<>();
+        Level rootLevel = Level.INFO;
+
+        for (Map.Entry<String, String> environmentVariable : environment.entrySet()) {
+            String envVarKey = environmentVariable.getKey();
+            String envVarValue = environmentVariable.getValue();
+
+            if (envVarKey.equals(ROOT_LOGLEVEL_ENV_VAR_NAME)) {
+                Optional<Level> newRootLogLevel = levelFromString(envVarValue);
+                if (newRootLogLevel.isPresent()) {
+                    rootLevel = newRootLogLevel.get();
+                } else {
+                    printlnInvalidEnvironmentVariableWarning(envVarKey, envVarValue);
+                }
+
+                continue;
+            }
+
+            if (envVarKey.startsWith(LOGLEVEL_ENV_VAR_PREFIX)) {
+                String loggerName = envVarKey.substring(LOGLEVEL_ENV_VAR_PREFIX.length());
+                Optional<Level> loggerLevel = levelFromString(envVarValue);
+
+                if (loggerLevel.isPresent()) {
+                    // Environment variables cannot contain dots. To delimit logger names in environment variables,
+                    // underscore is used instead. The rest of this logger implementation uses dots as the delimiter,
+                    // so we normalize them here before proceeding.
+                    String normalizedLoggerName = loggerName.replaceAll(
+                            Pattern.quote(ENV_VAR_LOGGER_NAME_SEGMENT_DELIMITER),
+                            LOGGER_NAME_SEGMENT_DELIMITER
+                    );
+
+                    logLevels.put(normalizedLoggerName, loggerLevel.get());
+                } else {
+                    printlnInvalidEnvironmentVariableWarning(envVarKey, envVarValue);
+                }
+            }
+        }
+
+        return new LoggingConfiguration(rootLevel, logLevels);
+    }
+
+    private static Optional<Level> levelFromString(String logLevelString) {
+        switch (logLevelString.toLowerCase()) {
+            case "debug":
+                return Optional.of(Level.DEBUG);
+            case "info":
+                return Optional.of(Level.INFO);
+            case "warn":
+                return Optional.of(Level.WARN);
+            case "trace":
+                return Optional.of(Level.TRACE);
+            case "error":
+                return Optional.of(Level.ERROR);
+            default:
+                return Optional.empty();
+        }
+    }
+
+    private static void printlnInvalidEnvironmentVariableWarning(String envVarKey, String envVarValue) {
+        System.err.printf("WARNING: Environment variable '%s' contains unknown log level '%s'.\n", envVarKey, envVarValue);
+        System.err.printf("WARNING: Environment variable '%s' will be ignored!\n", envVarKey);
+    }
+
+    private static final String ROOT_LOGLEVEL_ENV_VAR_NAME = "SF_FN_LOGLEVEL";
+    private static final String LOGLEVEL_ENV_VAR_PREFIX = ROOT_LOGLEVEL_ENV_VAR_NAME + "_";
+    private static final String ENV_VAR_LOGGER_NAME_SEGMENT_DELIMITER = "_";
+}

--- a/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/LoggingFormatter.java
+++ b/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/LoggingFormatter.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.slf4j.event.Level;
+
+public interface LoggingFormatter {
+    String format(String loggerName, Level level, String message);
+}

--- a/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/Utils.java
+++ b/sf-fx-runtime-java-logger/src/main/java/com/salesforce/functions/jvm/runtime/logger/Utils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+
+import java.util.regex.Pattern;
+
+import static com.salesforce.functions.jvm.runtime.logger.Constants.LOGGER_NAME_SEGMENT_DELIMITER;
+
+public class Utils {
+
+    public static String shortenLoggerName(String loggerName, int maxLength) {
+        String[] loggerNameSegments = loggerName.split(Pattern.quote(LOGGER_NAME_SEGMENT_DELIMITER));
+
+        String result = "";
+        for (int i = 0; i < loggerNameSegments.length; i++) {
+            result = String.join(LOGGER_NAME_SEGMENT_DELIMITER, loggerNameSegments);
+
+            if (result.length() <= maxLength) {
+                break;
+            }
+
+            if (loggerNameSegments[i].length() > 1) {
+                loggerNameSegments[i] = loggerNameSegments[i].substring(0, 1);
+            }
+        }
+
+        return result;
+    }
+}

--- a/sf-fx-runtime-java-logger/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/sf-fx-runtime-java-logger/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package org.slf4j.impl;
+
+import com.salesforce.functions.jvm.runtime.logger.FunctionsLoggerFactory;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.spi.LoggerFactoryBinder;
+
+public class StaticLoggerBinder implements LoggerFactoryBinder {
+    private final ILoggerFactory loggerFactory;
+
+    public StaticLoggerBinder() {
+        this.loggerFactory = new FunctionsLoggerFactory();
+    }
+
+    public static StaticLoggerBinder getSingleton() {
+        return SINGLETON;
+    }
+
+    @Override
+    public ILoggerFactory getLoggerFactory() {
+        return loggerFactory;
+    }
+
+    @Override
+    public String getLoggerFactoryClassStr() {
+        return FunctionsLoggerFactory.class.getName();
+    }
+
+    // To avoid constant folding by the compiler, this field must *not* be final!
+    public static String REQUESTED_API_VERSION = "1.6.99";
+
+    private static final StaticLoggerBinder SINGLETON = new StaticLoggerBinder();
+}

--- a/sf-fx-runtime-java-logger/src/main/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/sf-fx-runtime-java-logger/src/main/java/org/slf4j/impl/StaticMDCBinder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package org.slf4j.impl;
+
+import org.slf4j.helpers.BasicMDCAdapter;
+import org.slf4j.spi.MDCAdapter;
+
+public class StaticMDCBinder {
+
+    private StaticMDCBinder() {
+    }
+
+    public static StaticMDCBinder getSingleton() {
+        return SINGLETON;
+    }
+
+    public MDCAdapter getMDCA() {
+        return new BasicMDCAdapter();
+    }
+
+    public String getMDCAdapterClassStr() {
+        return BasicMDCAdapter.class.getName();
+    }
+
+    public static final StaticMDCBinder SINGLETON = new StaticMDCBinder();
+}

--- a/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/DefaultLoggingFormatterTest.java
+++ b/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/DefaultLoggingFormatterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+import org.slf4j.event.Level;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class DefaultLoggingFormatterTest {
+    private final LoggingFormatter formatter = new DefaultLoggingFormatter(Clock.fixed(Instant.EPOCH, ZoneId.of("UTC")));
+
+    @Before
+    public void clearAndSetMDC() {
+        MDC.clear();
+        MDC.put("function-invocation-id","e3a4ae2b-fefb-4277-89d0-7068e7e39b99");
+    }
+
+    @Test
+    public void test_1() {
+        String result = formatter.format("foo.bar.baz", Level.DEBUG, "This is a message!");
+        Assert.assertEquals("00:00:00.000 DEBUG [INVOCATION e3a4ae2b-fefb-4277-89d0-7068e7e39b99] foo.bar.baz - This is a message!\n", result);
+    }
+
+    @Test
+    public void testShortenedLoggerName() {
+        String result = formatter.format("com.salesforce.functions.jvm.runtime.logger.ClassName", Level.WARN, "This is a message!");
+        Assert.assertEquals("00:00:00.000 WARN  [INVOCATION e3a4ae2b-fefb-4277-89d0-7068e7e39b99] c.s.f.jvm.runtime.logger.ClassName - This is a message!\n", result);
+    }
+
+    @Test
+    public void testEmptyMDC() {
+        MDC.clear();
+        String result = formatter.format("com.salesforce.functions.jvm.runtime.logger.EmptyMDC", Level.TRACE, "This is a message!");
+        Assert.assertEquals("00:00:00.000 TRACE [INVOCATION null] c.s.f.jvm.runtime.logger.EmptyMDC - This is a message!\n", result);
+    }
+}

--- a/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLoggerTest.java
+++ b/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLoggerTest.java
@@ -15,10 +15,13 @@ import org.slf4j.event.Level;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Scanner;
 
 public class FunctionsLoggerTest {
     private final PrintStream previousSystemOut = System.out;
+    private final PrintStream previousSystemErr = System.err;
     private final ByteArrayOutputStream systemOutContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream systemErrContent = new ByteArrayOutputStream();
 
     private static final class TestingLoggingFormatter implements LoggingFormatter {
         @Override
@@ -33,65 +36,76 @@ public class FunctionsLoggerTest {
     @Before
     public void redirectOutputStreams() {
         System.setOut(new PrintStream(systemOutContent));
+        System.setErr(new PrintStream(systemErrContent));
     }
 
     @After
     public void restoreOutputStreams() {
         System.setOut(previousSystemOut);
+        System.setErr(previousSystemErr);
     }
 
     @Test
     public void testIgnoredLogLevel_1() {
         fooBarInfoLogger.debug("Hello World!");
         Assert.assertEquals("", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
     }
 
     @Test
     public void testIgnoredLogLevel_2() {
         fooBarInfoLogger.trace("Hello World!");
         Assert.assertEquals("", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
     }
 
     @Test
     public void testIgnoredLogLevel_3() {
         barBazDebugLogger.trace("Hello World!");
         Assert.assertEquals("", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
     }
 
     @Test
     public void testExactLogLevel() {
         fooBarInfoLogger.info("Hello exact world!");
         Assert.assertEquals("foo.bar INFO - Hello exact world!", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
     }
 
     @Test
     public void testHigherLogLevel_1() {
         fooBarInfoLogger.warn("Hello higher world!");
         Assert.assertEquals("foo.bar WARN - Hello higher world!", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
     }
 
     @Test
     public void testHigherLogLevel_2() {
         fooBarInfoLogger.error("Hello higher world!");
         Assert.assertEquals("foo.bar ERROR - Hello higher world!", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
     }
 
     @Test
     public void testFormattedMessage_1() {
         barBazDebugLogger.debug("Hello {}!", "World");
         Assert.assertEquals("bar.baz DEBUG - Hello World!", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
     }
 
     @Test
     public void testFormattedMessage_2() {
         barBazDebugLogger.debug("{} {}!", 23, "people");
         Assert.assertEquals("bar.baz DEBUG - 23 people!", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
     }
 
     @Test
     public void testFormattedMessage_3() {
         fooBarInfoLogger.warn("{} {} {} {} {} {}...", 4, 8, 15, 16, 23, 42);
         Assert.assertEquals("foo.bar WARN - 4 8 15 16 23 42...", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
     }
 
     @Test
@@ -105,5 +119,30 @@ public class FunctionsLoggerTest {
 
         fooBarInfoLogger.error("Result: {}", new Foo());
         Assert.assertEquals("foo.bar ERROR - Result: Foo {internal=bar}", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
+    }
+
+    @Test
+    public void testException_1() {
+        fooBarInfoLogger.error("Exception while processing data!", new Exception("Some useful error description"));
+        Assert.assertEquals("foo.bar ERROR - Exception while processing data!", systemOutContent.toString());
+
+        Scanner scanner = new Scanner(systemErrContent.toString());
+        Assert.assertEquals("java.lang.Exception: Some useful error description", scanner.nextLine());
+        while (scanner.hasNext()) {
+            Assert.assertTrue(scanner.nextLine().matches("\tat .*?\\((.*?:\\d+|Native Method)\\)"));
+        }
+    }
+
+    @Test
+    public void testException_2() {
+        fooBarInfoLogger.error("{} = {} and Exception", "a", "b", new Exception("Some useful error description"));
+        Assert.assertEquals("foo.bar ERROR - a = b and Exception", systemOutContent.toString());
+
+        Scanner scanner = new Scanner(systemErrContent.toString());
+        Assert.assertEquals("java.lang.Exception: Some useful error description", scanner.nextLine());
+        while (scanner.hasNext()) {
+            Assert.assertTrue(scanner.nextLine().matches("\tat .*?\\((.*?:\\d+|Native Method)\\)"));
+        }
     }
 }

--- a/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLoggerTest.java
+++ b/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/FunctionsLoggerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.event.Level;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class FunctionsLoggerTest {
+    private final PrintStream previousSystemOut = System.out;
+    private final ByteArrayOutputStream systemOutContent = new ByteArrayOutputStream();
+
+    private static final class TestingLoggingFormatter implements LoggingFormatter {
+        @Override
+        public String format(String loggerName, Level level, String message) {
+            return String.format("%s %s - %s", loggerName, level.toString(), message);
+        }
+    }
+
+    private final FunctionsLogger fooBarInfoLogger = new FunctionsLogger("foo.bar", Level.INFO, new TestingLoggingFormatter());
+    private final FunctionsLogger barBazDebugLogger = new FunctionsLogger("bar.baz", Level.DEBUG, new TestingLoggingFormatter());
+
+    @Before
+    public void redirectOutputStreams() {
+        System.setOut(new PrintStream(systemOutContent));
+    }
+
+    @After
+    public void restoreOutputStreams() {
+        System.setOut(previousSystemOut);
+    }
+
+    @Test
+    public void testIgnoredLogLevel_1() {
+        fooBarInfoLogger.debug("Hello World!");
+        Assert.assertEquals("", systemOutContent.toString());
+    }
+
+    @Test
+    public void testIgnoredLogLevel_2() {
+        fooBarInfoLogger.trace("Hello World!");
+        Assert.assertEquals("", systemOutContent.toString());
+    }
+
+    @Test
+    public void testIgnoredLogLevel_3() {
+        barBazDebugLogger.trace("Hello World!");
+        Assert.assertEquals("", systemOutContent.toString());
+    }
+
+    @Test
+    public void testExactLogLevel() {
+        fooBarInfoLogger.info("Hello exact world!");
+        Assert.assertEquals("foo.bar INFO - Hello exact world!", systemOutContent.toString());
+    }
+
+    @Test
+    public void testHigherLogLevel_1() {
+        fooBarInfoLogger.warn("Hello higher world!");
+        Assert.assertEquals("foo.bar WARN - Hello higher world!", systemOutContent.toString());
+    }
+
+    @Test
+    public void testHigherLogLevel_2() {
+        fooBarInfoLogger.error("Hello higher world!");
+        Assert.assertEquals("foo.bar ERROR - Hello higher world!", systemOutContent.toString());
+    }
+
+    @Test
+    public void testFormattedMessage_1() {
+        barBazDebugLogger.debug("Hello {}!", "World");
+        Assert.assertEquals("bar.baz DEBUG - Hello World!", systemOutContent.toString());
+    }
+
+    @Test
+    public void testFormattedMessage_2() {
+        barBazDebugLogger.debug("{} {}!", 23, "people");
+        Assert.assertEquals("bar.baz DEBUG - 23 people!", systemOutContent.toString());
+    }
+
+    @Test
+    public void testFormattedMessage_3() {
+        fooBarInfoLogger.warn("{} {} {} {} {} {}...", 4, 8, 15, 16, 23, 42);
+        Assert.assertEquals("foo.bar WARN - 4 8 15 16 23 42...", systemOutContent.toString());
+    }
+
+    @Test
+    public void testFormattedMessage_4() {
+        class Foo {
+            @Override
+            public String toString() {
+                return "Foo {internal=bar}";
+            }
+        }
+
+        fooBarInfoLogger.error("Result: {}", new Foo());
+        Assert.assertEquals("foo.bar ERROR - Result: Foo {internal=bar}", systemOutContent.toString());
+    }
+}

--- a/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/LoggingConfigurationTest.java
+++ b/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/LoggingConfigurationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.event.Level;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LoggingConfigurationTest {
+    @Test
+    public void testLogLevelResolution() {
+        Map<String, Level> logLevelByLoggerNames = new HashMap<>();
+        logLevelByLoggerNames.put("foo", Level.ERROR);
+        logLevelByLoggerNames.put("foo.bar", Level.WARN);
+        logLevelByLoggerNames.put("x.y.z", Level.DEBUG);
+
+        LoggingConfiguration configuration = new LoggingConfiguration(Level.INFO, logLevelByLoggerNames);
+
+        Map<String, Level> expectedLogLevels = new HashMap<>();
+        expectedLogLevels.put("foo", Level.ERROR);
+        expectedLogLevels.put("foo.bar", Level.WARN);
+        expectedLogLevels.put("x.y.z", Level.DEBUG);
+
+        expectedLogLevels.put("foo.bar.baz", Level.WARN);
+        expectedLogLevels.put("x.y.z.foo.bar", Level.DEBUG);
+
+        expectedLogLevels.put("x.y", Level.INFO);
+        expectedLogLevels.put("com.salesforce", Level.INFO);
+
+        expectedLogLevels.put("", Level.INFO);
+        expectedLogLevels.put("....", Level.INFO);
+
+        for (Map.Entry<String, Level> entry : expectedLogLevels.entrySet()) {
+            Assert.assertEquals(entry.getValue(), configuration.getLogLevelForLoggerName(entry.getKey()));
+        }
+    }
+}
+

--- a/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/LoggingConfiguratorTest.java
+++ b/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/LoggingConfiguratorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.event.Level;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LoggingConfiguratorTest {
+    private final PrintStream previousSystemOut = System.out;
+    private final PrintStream previousSystemErr = System.err;
+    private final ByteArrayOutputStream systemOutContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream systemErrContent = new ByteArrayOutputStream();
+
+    @Before
+    public void redirectOutputStreams() {
+        System.setOut(new PrintStream(systemOutContent));
+        System.setErr(new PrintStream(systemErrContent));
+    }
+
+    @After
+    public void restoreOutputStreams() {
+        System.setOut(previousSystemOut);
+        System.setErr(previousSystemErr);
+    }
+
+    @Test
+    public void testRootLevelConfiguration() {
+        Map<String, Level> expectations = new HashMap<>();
+        expectations.put("DEBUG", Level.DEBUG);
+        expectations.put("INFO", Level.INFO);
+        expectations.put("WARN", Level.WARN);
+        expectations.put("TRACE", Level.TRACE);
+        expectations.put("ERROR", Level.ERROR);
+
+        expectations.put("DEBUg", Level.DEBUG);
+        expectations.put("info", Level.INFO);
+        expectations.put("WArN", Level.WARN);
+        expectations.put("TRAcE", Level.TRACE);
+        expectations.put("Error", Level.ERROR);
+
+        for (Map.Entry<String, Level> entry : expectations.entrySet()) {
+            Map<String, String> environment = new HashMap<>();
+            environment.put("SF_FN_LOGLEVEL", entry.getKey());
+
+            LoggingConfiguration configuration = LoggingConfigurator.configureFromEnvironment(environment);
+            Assert.assertEquals(entry.getValue(), configuration.getRootLogLevel());
+        }
+
+        Assert.assertEquals("", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
+    }
+
+    @Test
+    public void testInvalidRootLevelConfiguration() {
+        Map<String, String> environment = new HashMap<>();
+        environment.put("SF_FN_LOGLEVEL", "debugg");
+
+        LoggingConfiguration configuration = LoggingConfigurator.configureFromEnvironment(environment);
+        Assert.assertEquals(Level.INFO, configuration.getRootLogLevel());
+        Assert.assertEquals("", systemOutContent.toString());
+        Assert.assertEquals("WARNING: Environment variable 'SF_FN_LOGLEVEL' contains unknown log level 'debugg'.\nWARNING: Environment variable 'SF_FN_LOGLEVEL' will be ignored!\n", systemErrContent.toString());
+    }
+
+    @Test
+    public void testLoggerSpecificLevelConfiguration() {
+        Map<String, String> environment = new HashMap<>();
+        environment.put("SF_FN_LOGLEVEL_com_salesforce", "debug");
+        environment.put("SF_FN_LOGLEVEL_com_salesforce_functions_jvm_internal", "WARN");
+
+        LoggingConfiguration configuration = LoggingConfigurator.configureFromEnvironment(environment);
+
+        Assert.assertEquals(Level.DEBUG, configuration.getLogLevelForLoggerName("com.salesforce"));
+        Assert.assertEquals(Level.DEBUG, configuration.getLogLevelForLoggerName("com.salesforce.functions"));
+        Assert.assertEquals(Level.DEBUG, configuration.getLogLevelForLoggerName("com.salesforce.functions.jvm"));
+        Assert.assertEquals(Level.WARN, configuration.getLogLevelForLoggerName("com.salesforce.functions.jvm.internal"));
+
+        Assert.assertEquals(Level.INFO, configuration.getRootLogLevel());
+        Assert.assertEquals("", systemOutContent.toString());
+        Assert.assertEquals("", systemErrContent.toString());
+    }
+
+    @Test
+    public void testInvalidLoggerSpecificLevelConfiguration() {
+        Map<String, String> environment = new HashMap<>();
+        environment.put("SF_FN_LOGLEVEL_com_salesforce", "debug");
+        environment.put("SF_FN_LOGLEVEL_com_salesforce_functions_jvm_internal", "HORSE");
+
+        LoggingConfiguration configuration = LoggingConfigurator.configureFromEnvironment(environment);
+
+        Assert.assertEquals(Level.DEBUG, configuration.getLogLevelForLoggerName("com.salesforce"));
+        Assert.assertEquals(Level.DEBUG, configuration.getLogLevelForLoggerName("com.salesforce.functions"));
+        Assert.assertEquals(Level.DEBUG, configuration.getLogLevelForLoggerName("com.salesforce.functions.jvm"));
+        Assert.assertEquals(Level.DEBUG, configuration.getLogLevelForLoggerName("com.salesforce.functions.jvm.internal"));
+
+        Assert.assertEquals(Level.INFO, configuration.getRootLogLevel());
+        Assert.assertEquals("", systemOutContent.toString());
+        Assert.assertEquals("WARNING: Environment variable 'SF_FN_LOGLEVEL_com_salesforce_functions_jvm_internal' contains unknown log level 'HORSE'.\nWARNING: Environment variable 'SF_FN_LOGLEVEL_com_salesforce_functions_jvm_internal' will be ignored!\n", systemErrContent.toString());
+    }
+}

--- a/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/UtilsTest.java
+++ b/sf-fx-runtime-java-logger/src/test/java/com/salesforce/functions/jvm/runtime/logger/UtilsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.functions.jvm.runtime.logger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class UtilsTest {
+
+    @Test
+    public void testShortenLoggerName() {
+        String loggerName = "mainPackage.sub.sample.Bar";
+
+        Map<Integer, String> expectations = new HashMap<>();
+        expectations.put(0, "m.s.s.Bar");
+        expectations.put(5, "m.s.s.Bar");
+        expectations.put(10, "m.s.s.Bar");
+        expectations.put(15, "m.s.sample.Bar");
+        expectations.put(16, "m.sub.sample.Bar");
+        expectations.put(26, "mainPackage.sub.sample.Bar");
+
+        for (Map.Entry<Integer, String> entry : expectations.entrySet()) {
+            Assert.assertEquals(entry.getValue(), Utils.shortenLoggerName(loggerName, entry.getKey()));
+        }
+    }
+}

--- a/sf-fx-runtime-java-runtime/pom.xml
+++ b/sf-fx-runtime-java-runtime/pom.xml
@@ -193,6 +193,14 @@
                   <overWrite>true</overWrite>
                   <destFileName>sdk-impl-v0.jar</destFileName>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>${parent.groupId}</groupId>
+                  <artifactId>sf-fx-runtime-java-logger</artifactId>
+                  <version>${parent.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <destFileName>sf-fx-java-logger.jar</destFileName>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
               <overWriteReleases>true</overWriteReleases>
@@ -226,6 +234,9 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.6</version>
+        <configuration>
+          <excludes>*.jar</excludes>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/Project.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/Project.java
@@ -10,18 +10,29 @@ package com.salesforce.functions.jvm.runtime.project;
 import com.salesforce.functions.jvm.runtime.project.util.ProjectClassLoaderBuilder;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public abstract class Project {
     abstract public String getTypeName();
+
     abstract public List<Path> getClasspathPaths();
-    private ClassLoader classLoader;
 
-    public ClassLoader getClassLoader() {
-        if (this.classLoader == null) {
-            classLoader = ProjectClassLoaderBuilder.build(getClasspathPaths());
-        }
+    /**
+     * Creates a class loader for this project. It also allows the caller to inject JAR files that do not originate from
+     * project. Injected JAR files are guaranteed to come first in the class loader created by this method. The main
+     * use-case for this is injecting slf4j logger bindings into the project, ensuring they are picked up before
+     * any other bindings within the project.
+     *
+     * @param injectJarsPaths Paths to JAR files that are injected into the project class loader.
+     * @return A class loader for the project and injected JAR files.
+     */
+    public final ClassLoader createClassLoader(Path... injectJarsPaths) {
+        // Order of injectJarPaths and getClasspathPaths() is important. See Javadoc for details!
+        List<Path> paths = new ArrayList<>(Arrays.asList(injectJarsPaths));
+        paths.addAll(getClasspathPaths());
 
-        return classLoader;
+        return ProjectClassLoaderBuilder.build(paths);
     }
 }

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/util/ProjectClassLoaderBuilder.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/util/ProjectClassLoaderBuilder.java
@@ -29,6 +29,8 @@ public final class ProjectClassLoaderBuilder {
      * @return The new class loader.
      */
     public static ClassLoader build(List<Path> paths) {
+        // NOTE: It's important to keep the order of the given paths since URLClassLoader will load classes in the
+        // given order. See com.salesforce.functions.jvm.runtime.project.Project#createClassLoader for details.
         URL[] urls = new URL[paths.size()];
         for (int i = 0; i < urls.length; i++) {
             urls[i] = pathToURLClassLoaderURL(paths.get(i));
@@ -39,9 +41,7 @@ public final class ProjectClassLoaderBuilder {
         // This creates a strong isolation of function runtime classloading and the function provided by the user.
         ClassLoader bootstrapClassLoader = ClassLoader.getSystemClassLoader().getParent();
 
-                return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
-            return new URLClassLoader(urls, bootstrapClassLoader);
-        });
+        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> new URLClassLoader(urls, bootstrapClassLoader));
     }
 
     private static URL pathToURLClassLoaderURL(Path path) {
@@ -63,5 +63,6 @@ public final class ProjectClassLoaderBuilder {
         }
     }
 
-    private ProjectClassLoaderBuilder() {}
+    private ProjectClassLoaderBuilder() {
+    }
 }

--- a/sf-fx-runtime-java-runtime/src/main/resources/logback.xml
+++ b/sf-fx-runtime-java-runtime/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [RUNTIME] %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Adds an [slf4j](http://www.slf4j.org/) compatible logger implementation in the `sf-fx-runtime-java-logger` module. This module is used by the runtime to inject the logger to the project class path. It will be picked up by slf4j and automatically used for the function.

Users can define the log level with the `SF_FN_LOGLEVEL` environment variable and will default to `INFO`. The log level can be individually set for classes/packages with an environment variable like this one: `SF_FN_LOGLEVEL_com_salesforce`.

If the function project contains another slf4j implementation such as logback, slf4j will complain about the ambiguity but will also use the function logger since it's the first binding loaded by the class loader. ([Reference](https://github.com/forcedotcom/sf-fx-runtime-java/pull/12/files#diff-55bb361bbb1f8f07db34bfd4a82a17bf4566bab038ca287705c322c02ffdd4ffR22-R36))

Function invocation has been changed to put the invocation id into slf4j's MDC which is then used by the new function logger to add that id to each logged line automatically.

Example output:

```
15:19:35.257 INFO  [RUNTIME] c.s.f.j.r.commands.ServeCommand - Detecting project type at path /Users/malax/projects/my-function...
15:19:37.407 INFO  [RUNTIME] c.s.f.j.r.commands.ServeCommand - Detected Maven project at path /Users/malax/projects/my-function after 2149ms!
15:19:37.407 INFO  [RUNTIME] c.s.f.j.r.commands.ServeCommand - Scanning project for functions...
15:19:37.616 INFO  [RUNTIME] c.s.f.j.r.commands.ServeCommand - Found 1 function(s) after 208ms.
15:19:37.617 INFO  [RUNTIME] c.s.f.j.r.commands.ServeCommand - Found function: UNIMPLEMENTED
15:19:37.642 INFO  [RUNTIME] io.undertow - starting server: Undertow - 2.1.1.Final
15:19:37.649 INFO  [RUNTIME] org.xnio - XNIO version 3.8.0.Final
15:19:37.658 INFO  [RUNTIME] org.xnio.nio - XNIO NIO Implementation Version 3.8.0.Final
15:19:37.744 INFO  [RUNTIME] org.jboss.threads - JBoss Threads version 3.1.0.Final
15:19:48.390 DEBUG [INVOCATION 00Dxx0000006IYJEA2-4Y4W3Lw_LkoskcHdEaZze--MyFunction-836771b8962e79054aaff52b] c.s.f.jvm.examples.LoggingFunction - Hello world from logger!
15:19:49.325 INFO  [INVOCATION 00Dxx0000006IYJEA2-4Y4W3Lw_LkoskcHdEaZze--MyFunction-836771b8962e79054aaff52b] c.s.f.j.examples.ContentTypeDetector - Response content type was: Content-Type: text/html
```
Closes [W-9041771](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000008sUrYAI/view)