### PR TITLE
Add switch to configure host to bind to

### DIFF
--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ServeCommand.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ServeCommand.java
@@ -39,8 +39,15 @@ public class ServeCommand implements Callable<Integer> {
 
   @Option(
       names = {"-p", "--port"},
-      description = "The port the webserver should listen on.")
-  private int port = 8080;
+      description = "The port the webserver should listen on. Defaults to '8080'.",
+      defaultValue = "8080")
+  private int port;
+
+  @Option(
+      names = {"-h", "--host"},
+      description = "The host the webserver should listen on. Defaults to '0.0.0.0'.",
+      defaultValue = "0.0.0.0")
+  private String host;
 
   private final List<ProjectBuilder> projectBuilders =
       Arrays.asList(new FunctionBundleProjectBuilder(), new MavenProjectBuilder());
@@ -95,6 +102,6 @@ public class ServeCommand implements Callable<Integer> {
 
   private InvocationInterface<CloudEvent, SalesforceFunctionResult, SalesforceFunctionException>
       createInvocationInterface() {
-    return new UndertowInvocationInterface(port);
+    return new UndertowInvocationInterface(port, host);
   }
 }

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ServeCommand.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ServeCommand.java
@@ -45,8 +45,8 @@ public class ServeCommand implements Callable<Integer> {
 
   @Option(
       names = {"-h", "--host"},
-      description = "The host the webserver should listen on. Defaults to '0.0.0.0'.",
-      defaultValue = "0.0.0.0")
+      description = "The host the webserver should bind to. Defaults to 'localhost'.",
+      defaultValue = "localhost")
   private String host;
 
   private final List<ProjectBuilder> projectBuilders =

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/UndertowInvocationInterface.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/UndertowInvocationInterface.java
@@ -35,10 +35,12 @@ public class UndertowInvocationInterface
     implements InvocationInterface<
         CloudEvent, SalesforceFunctionResult, SalesforceFunctionException> {
   private final int port;
+  private final String host;
   private static final Logger LOGGER = LoggerFactory.getLogger(UndertowInvocationInterface.class);
 
-  public UndertowInvocationInterface(int port) {
+  public UndertowInvocationInterface(int port, String host) {
     this.port = port;
+    this.host = host;
   }
 
   @Override
@@ -48,7 +50,7 @@ public class UndertowInvocationInterface
       throws Exception {
     Undertow undertow =
         Undertow.builder()
-            .addHttpListener(port, "")
+            .addHttpListener(port, host)
             .setHandler(new ProjectFunctionHandler(projectFunction))
             .build();
 


### PR DESCRIPTION
Serving a function previously bound the HTTP server to `localhost` only. Added an optional command line switch (`-h`, `--host`) to explicitly configure the host if necessary, usually in containers where the server should bind to `0.0.0.0`.

Closes [W-9112919](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000AObjYAG/view)