### PR TITLE
Improve RestApi error handling + Unit Tests

### DIFF
--- a/sf-fx-runtime-java-sdk-impl-v0/pom.xml
+++ b/sf-fx-runtime-java-sdk-impl-v0/pom.xml
@@ -59,6 +59,12 @@
       <version>2.27.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.5.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/AbstractQueryRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/AbstractQueryRestApiRequest.java
@@ -20,12 +20,12 @@ public abstract class AbstractQueryRestApiRequest implements RestApiRequest<Quer
 
   @Override
   public final QueryRecordResult processResponse(
-      int statusCode, Map<String, String> headers, JsonElement json) throws RestApiException {
+      int statusCode, Map<String, String> headers, JsonElement json) throws RestApiErrorsException {
 
     final Gson gson = new Gson();
 
     if (statusCode != 200) {
-      throw new RestApiException(ErrorResponseParser.parse(json));
+      throw new RestApiErrorsException(ErrorResponseParser.parse(json));
     } else {
       final JsonObject body = json.getAsJsonObject();
       final boolean done = body.get("done").getAsBoolean();

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CompositeRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CompositeRestApiRequest.java
@@ -86,7 +86,7 @@ public class CompositeRestApiRequest<T> implements RestApiRequest<Map<String, T>
 
   @Override
   public Map<String, T> processResponse(
-      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiException {
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
     Map<String, T> result = new HashMap<>();
 
     if (statusCode == 200) {
@@ -113,19 +113,19 @@ public class CompositeRestApiRequest<T> implements RestApiRequest<Map<String, T>
                   .get(referenceId)
                   .processResponse(subrequestStatusCode, subrequestHeaders, subrequestBody));
 
-        } catch (RestApiException e) {
+        } catch (RestApiErrorsException e) {
           errors.addAll(e.getApiErrors());
         }
       }
 
       if (!errors.isEmpty()) {
-        throw new RestApiException(errors);
+        throw new RestApiErrorsException(errors);
       }
 
       return result;
     }
 
-    throw new RestApiException(ErrorResponseParser.parse(body));
+    throw new RestApiErrorsException(ErrorResponseParser.parse(body));
   }
 
   private static String httpMethodToCompositeMethodString(HttpMethod method) {

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CompositeRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CompositeRestApiRequest.java
@@ -40,14 +40,10 @@ public class CompositeRestApiRequest<T> implements RestApiRequest<Map<String, T>
   }
 
   @Override
-  public URI createUri(URI baseUri, String apiVersion) {
-    try {
-      return new URIBuilder(baseUri)
-          .setPathSegments("services", "data", "v" + apiVersion, "composite")
-          .build();
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("Unexpected URISyntaxException!", e);
-    }
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "composite")
+        .build();
   }
 
   @Override
@@ -66,14 +62,19 @@ public class CompositeRestApiRequest<T> implements RestApiRequest<Map<String, T>
         throw new RuntimeException("Unexpected HTTP method: " + entry.getValue().getHttpMethod());
       }
 
-      // RestApiRequest#createUri return an absolute URL. For a composite request, we need to strip
+      // RestApiRequest#createUri returns an absolute URL. For a composite request, we need to strip
       // off the base URL from the returned value.
-      final String url =
-          entry
-              .getValue()
-              .createUri(baseUri, apiVersion)
-              .toString()
-              .substring(baseUri.toString().length());
+      final String url;
+      try {
+        url =
+            entry
+                .getValue()
+                .createUri(baseUri, apiVersion)
+                .toString()
+                .substring(baseUri.toString().length());
+      } catch (URISyntaxException e) {
+        throw new RuntimeException("Unexpected URISyntaxException!", e);
+      }
 
       JsonObject subrequestJson = new JsonObject();
       subrequestJson.addProperty("method", method);

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
@@ -47,12 +47,11 @@ public class CreateRecordRestApiRequest implements RestApiRequest<ModifyRecordRe
 
   @Override
   public ModifyRecordResult processResponse(
-      int statusCode, Map<String, String> headers, JsonElement body) {
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiException {
     if (statusCode == 201) {
       return new ModifyRecordResult(body.getAsJsonObject().get("id").getAsString());
+    } else {
+      throw new RestApiException(ErrorResponseParser.parse(body));
     }
-
-    throw new RuntimeException(
-        "Unimplemented error handling! Status code: " + statusCode + "\n" + body.toString());
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
@@ -30,14 +30,10 @@ public class CreateRecordRestApiRequest implements RestApiRequest<ModifyRecordRe
   }
 
   @Override
-  public URI createUri(URI baseUri, String apiVersion) {
-    try {
-      return new URIBuilder(baseUri)
-          .setPathSegments("services", "data", "v" + apiVersion, "sobjects", type)
-          .build();
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("Unexpected URISyntaxException!", e);
-    }
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "sobjects", type)
+        .build();
   }
 
   @Override

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
@@ -43,11 +43,11 @@ public class CreateRecordRestApiRequest implements RestApiRequest<ModifyRecordRe
 
   @Override
   public ModifyRecordResult processResponse(
-      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiException {
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
     if (statusCode == 201) {
       return new ModifyRecordResult(body.getAsJsonObject().get("id").getAsString());
     } else {
-      throw new RestApiException(ErrorResponseParser.parse(body));
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
     }
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/ModifyRecordResult.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/ModifyRecordResult.java
@@ -6,14 +6,35 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
-public class ModifyRecordResult {
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+public final class ModifyRecordResult {
   private final String id;
 
   public ModifyRecordResult(String id) {
     this.id = id;
   }
 
+  @Nonnull
   public String getId() {
     return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ModifyRecordResult that = (ModifyRecordResult) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryNextRecordsRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryNextRecordsRestApiRequest.java
@@ -25,12 +25,8 @@ public class QueryNextRecordsRestApiRequest extends AbstractQueryRestApiRequest 
   }
 
   @Override
-  public URI createUri(URI baseUri, String apiVersion) {
-    try {
-      return new URIBuilder(baseUri).setPath(nextRecordsPath).build();
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("Unexpected URISyntaxException!", e);
-    }
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri).setPath(nextRecordsPath).build();
   }
 
   @Override

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordRestApiRequest.java
@@ -25,15 +25,11 @@ public class QueryRecordRestApiRequest extends AbstractQueryRestApiRequest {
   }
 
   @Override
-  public URI createUri(URI baseUri, String apiVersion) {
-    try {
-      return new URIBuilder(baseUri)
-          .setPathSegments("services", "data", "v" + apiVersion, "query")
-          .setParameter("q", soql)
-          .build();
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("Unexpected URISyntaxException!", e);
-    }
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "query")
+        .setParameter("q", soql)
+        .build();
   }
 
   @Override

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResult.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResult.java
@@ -37,4 +37,24 @@ public final class QueryRecordResult {
   public Optional<String> getNextRecordsPath() {
     return Optional.ofNullable(nextRecordsPath);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QueryRecordResult result = (QueryRecordResult) o;
+    return totalSize == result.totalSize
+        && done == result.done
+        && Objects.equals(records, result.records)
+        && Objects.equals(nextRecordsPath, result.nextRecordsPath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(totalSize, done, records, nextRecordsPath);
+  }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/Record.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/Record.java
@@ -10,9 +10,9 @@ import com.google.gson.JsonPrimitive;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 
 public final class Record {
-
   private final Map<String, JsonPrimitive> attributes;
   private final Map<String, JsonPrimitive> values;
 
@@ -21,10 +21,12 @@ public final class Record {
     this.values = values;
   }
 
+  @Nonnull
   public Map<String, JsonPrimitive> getAttributes() {
     return Collections.unmodifiableMap(attributes);
   }
 
+  @Nonnull
   public Map<String, JsonPrimitive> getValues() {
     return Collections.unmodifiableMap(values);
   }
@@ -44,10 +46,5 @@ public final class Record {
   @Override
   public int hashCode() {
     return Objects.hash(attributes, values);
-  }
-
-  @Override
-  public String toString() {
-    return "Record{" + "attributes=" + attributes + ", values=" + values + '}';
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApi.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApi.java
@@ -54,7 +54,8 @@ public final class RestApi {
     return accessToken;
   }
 
-  public <T> T execute(RestApiRequest<T> apiRequest) throws RestApiException, IOException {
+  public <T> T execute(RestApiRequest<T> apiRequest)
+      throws RestApiErrorsException, RestApiException, IOException {
     URI uri;
     try {
       uri = apiRequest.createUri(salesforceBaseUrl, apiVersion);
@@ -88,7 +89,7 @@ public final class RestApi {
         return apiRequest.processResponse(
             response.getStatusLine().getStatusCode(), headers, bodyJsonElement);
       } catch (JsonSyntaxException e) {
-        throw new IOException(bodyString, e);
+        throw new RestApiException("Could not parse API response as JSON!", e);
       }
     }
   }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApi.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApi.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,7 +54,12 @@ public final class RestApi {
   }
 
   public <T> T execute(RestApiRequest<T> apiRequest) throws RestApiException, IOException {
-    URI uri = apiRequest.createUri(salesforceBaseUrl, apiVersion);
+    URI uri;
+    try {
+      uri = apiRequest.createUri(salesforceBaseUrl, apiVersion);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("Unexpected URISyntaxException!", e);
+    }
 
     HttpClient client = HttpClients.createDefault();
 

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiError.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiError.java
@@ -9,8 +9,9 @@ package com.salesforce.functions.jvm.runtime.sdk.restapi;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-public class RestApiError {
+public final class RestApiError {
   private final String message;
   private final String errorCode;
   private final List<String> fields;
@@ -31,5 +32,24 @@ public class RestApiError {
 
   public List<String> getFields() {
     return fields;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RestApiError that = (RestApiError) o;
+    return Objects.equals(message, that.message)
+        && Objects.equals(errorCode, that.errorCode)
+        && Objects.equals(fields, that.fields);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(message, errorCode, fields);
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiErrorsException.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiErrorsException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RestApiErrorsException extends Exception {
+  private final List<RestApiError> apiErrors;
+
+  public RestApiErrorsException(List<RestApiError> apiErrors) {
+    this.apiErrors = Collections.unmodifiableList(new ArrayList<>(apiErrors));
+  }
+
+  public List<RestApiError> getApiErrors() {
+    return apiErrors;
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiException.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiException.java
@@ -6,18 +6,9 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 public class RestApiException extends Exception {
-  private final List<RestApiError> apiErrors;
 
-  public RestApiException(List<RestApiError> apiErrors) {
-    this.apiErrors = Collections.unmodifiableList(new ArrayList<>(apiErrors));
-  }
-
-  public List<RestApiError> getApiErrors() {
-    return apiErrors;
+  public RestApiException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiRequest.java
@@ -8,13 +8,14 @@ package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
 import com.google.gson.JsonElement;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Optional;
 
 public interface RestApiRequest<T> {
   HttpMethod getHttpMethod();
 
-  URI createUri(URI baseUri, String apiVersion);
+  URI createUri(URI baseUri, String apiVersion) throws URISyntaxException;
 
   Optional<JsonElement> getBody();
 

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiRequest.java
@@ -20,5 +20,5 @@ public interface RestApiRequest<T> {
   Optional<JsonElement> getBody();
 
   T processResponse(int statusCode, Map<String, String> headers, JsonElement body)
-      throws RestApiException;
+      throws RestApiErrorsException;
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
@@ -46,11 +46,11 @@ public class UpdateRecordRestApiRequest implements RestApiRequest<ModifyRecordRe
 
   @Override
   public ModifyRecordResult processResponse(
-      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiException {
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
     if (statusCode == 204) {
       return new ModifyRecordResult(id);
     } else {
-      throw new RestApiException(ErrorResponseParser.parse(body));
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
     }
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
@@ -33,14 +33,10 @@ public class UpdateRecordRestApiRequest implements RestApiRequest<ModifyRecordRe
   }
 
   @Override
-  public URI createUri(URI baseUri, String apiVersion) {
-    try {
-      return new URIBuilder(baseUri)
-          .setPathSegments("services", "data", "v" + apiVersion, "sobjects", this.type, this.id)
-          .build();
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("Unexpected URISyntaxException!", e);
-    }
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "sobjects", this.type, this.id)
+        .build();
   }
 
   @Override

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
@@ -50,12 +50,11 @@ public class UpdateRecordRestApiRequest implements RestApiRequest<ModifyRecordRe
 
   @Override
   public ModifyRecordResult processResponse(
-      int statusCode, Map<String, String> headers, JsonElement body) {
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiException {
     if (statusCode == 204) {
       return new ModifyRecordResult(id);
+    } else {
+      throw new RestApiException(ErrorResponseParser.parse(body));
     }
-
-    throw new RuntimeException(
-        "Unimplemented error handling! Status code: " + statusCode + "\n" + body.toString());
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/ModifyRecordResultTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/ModifyRecordResultTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class ModifyRecordResultTest {
+
+  @Test
+  public void name() {
+    EqualsVerifier.forClass(ModifyRecordResult.class).verify();
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/ModifyRecordResultTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/ModifyRecordResultTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 public class ModifyRecordResultTest {
 
   @Test
-  public void name() {
+  public void testEqualsAndHashCode() {
     EqualsVerifier.forClass(ModifyRecordResult.class).verify();
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResultTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResultTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class QueryRecordResultTest {
+
+  @Test
+  public void testEqualsAndHashCode() {
+    EqualsVerifier.forClass(QueryRecordResult.class).verify();
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordBuilder.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import com.google.gson.JsonPrimitive;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class RecordBuilder {
+  public static Map<String, JsonPrimitive> map(Tuple... data) {
+    HashMap<String, JsonPrimitive> result = new HashMap<>();
+    for (Tuple tuple : data) {
+      result.put(tuple.getKey(), tuple.getValue());
+    }
+
+    return result;
+  }
+
+  public static class Tuple {
+    private final String key;
+    private final JsonPrimitive value;
+
+    public Tuple(String key, String value) {
+      this.key = key;
+      this.value = new JsonPrimitive(value);
+    }
+
+    public Tuple(String key, Number value) {
+      this.key = key;
+      this.value = new JsonPrimitive(value);
+    }
+
+    public Tuple(String key, Boolean value) {
+      this.key = key;
+      this.value = new JsonPrimitive(value);
+    }
+
+    public Tuple(String key, Character value) {
+      this.key = key;
+      this.value = new JsonPrimitive(value);
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public JsonPrimitive getValue() {
+      return value;
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
@@ -6,10 +6,28 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.gson.JsonPrimitive;
+import java.util.HashMap;
+import java.util.Map;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 public class RecordTest {
+
+  @Test
+  public void testValuesAndAttributesAreUnmodified() {
+    Map<String, JsonPrimitive> attributes = new HashMap<>();
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("foo", new JsonPrimitive("bar"));
+    values.put("bar", new JsonPrimitive("baz"));
+
+    Record record = new Record(attributes, values);
+    assertThat("attributes are unmodified", record.getAttributes(), equalTo(attributes));
+    assertThat("values are unmodified", record.getValues(), equalTo(values));
+  }
 
   @Test
   public void testEqualsAndHashCode() {

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 public class RecordTest {
 
   @Test
-  public void name() {
+  public void testEqualsAndHashCode() {
     EqualsVerifier.forClass(Record.class).verify();
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class RecordTest {
+
+  @Test
+  public void name() {
+    EqualsVerifier.forClass(Record.class).verify();
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.gson.JsonPrimitive;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RestApiCompositeTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "51.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void compositeSingleCreate() throws RestApiException, IOException {
+    Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
+
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("Name", new JsonPrimitive("Star Wars Episode IV - A New Hope"));
+    values.put("Rating__c", new JsonPrimitive("Excellent"));
+    subrequests.put("insert-anh", new CreateRecordRestApiRequest("Movie__c", values));
+
+    CompositeRestApiRequest<ModifyRecordResult> request =
+        new CompositeRestApiRequest<>(
+            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), subrequests);
+    Map<String, ModifyRecordResult> result = restApi.execute(request);
+
+    assertThat(
+        "",
+        result,
+        hasEntry(equalTo("insert-anh"), equalTo(new ModifyRecordResult("a00B000000FSkgxIAD"))));
+  }
+
+  @Test
+  public void compositeSingleCreateWithError() throws IOException {
+    Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
+
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("Name", new JsonPrimitive("Star Wars Episode IV - A New Hope"));
+    values.put("Rating__c", new JsonPrimitive("Amazing"));
+    subrequests.put("insert-anh", new CreateRecordRestApiRequest("Movie__c", values));
+
+    CompositeRestApiRequest<ModifyRecordResult> request =
+        new CompositeRestApiRequest<>(
+            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), subrequests);
+
+    try {
+      restApi.execute(request);
+    } catch (RestApiException e) {
+      assertThat(
+          "the error from the inner create request is in the error from the composite request",
+          e.getApiErrors(),
+          contains(
+              equalTo(
+                  new RestApiError(
+                      "Rating: bad value for restricted picklist field: Amazing",
+                      "INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST",
+                      Collections.singletonList("Rating__c")))));
+      return;
+    }
+
+    Assert.fail("Expected exception!");
+  }
+
+  @Test
+  public void compositeSingleUpdate() throws RestApiException, IOException {
+    Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
+
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
+    subrequests.put(
+        "update-esb", new UpdateRecordRestApiRequest("a00B000000FSjVUIA1", "Movie__c", values));
+
+    CompositeRestApiRequest<ModifyRecordResult> request =
+        new CompositeRestApiRequest<>(
+            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), subrequests);
+    Map<String, ModifyRecordResult> result = restApi.execute(request);
+
+    assertThat(
+        "",
+        result,
+        hasEntry(equalTo("update-esb"), equalTo(new ModifyRecordResult("a00B000000FSjVUIA1"))));
+  }
+
+  @Test
+  public void compositeCreateTree() throws RestApiException, IOException {
+    Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new LinkedHashMap<>();
+
+    Map<String, JsonPrimitive> valuesFranchise = new HashMap<>();
+    valuesFranchise.put("Name", new JsonPrimitive("Star Wars"));
+    subrequests.put(
+        "createFranchise", new CreateRecordRestApiRequest("Franchise__c", valuesFranchise));
+
+    Map<String, JsonPrimitive> valuesEp1 = new HashMap<>();
+    valuesEp1.put("Name", new JsonPrimitive("Star Wars Episode I - A Phantom Menace"));
+    valuesEp1.put("Franchise__c", new JsonPrimitive("@{createFranchise.id}"));
+    subrequests.put("createEp1", new CreateRecordRestApiRequest("Movie__c", valuesEp1));
+
+    Map<String, JsonPrimitive> valuesEp2 = new HashMap<>();
+    valuesEp2.put("Name", new JsonPrimitive("Star Wars Episode II - Attack Of The Clones"));
+    valuesEp2.put("Franchise__c", new JsonPrimitive("@{createFranchise.id}"));
+    subrequests.put("createEp2", new CreateRecordRestApiRequest("Movie__c", valuesEp2));
+
+    Map<String, JsonPrimitive> valuesEp3 = new HashMap<>();
+    valuesEp3.put("Name", new JsonPrimitive("Star Wars Episode III - Revenge Of The Sith"));
+    valuesEp3.put("Franchise__c", new JsonPrimitive("@{createFranchise.id}"));
+    subrequests.put("createEp3", new CreateRecordRestApiRequest("Movie__c", valuesEp3));
+
+    CompositeRestApiRequest<ModifyRecordResult> request =
+        new CompositeRestApiRequest<>(
+            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), subrequests);
+    Map<String, ModifyRecordResult> result = restApi.execute(request);
+
+    assertThat(
+        "the franchise was created",
+        result,
+        hasEntry(
+            equalTo("createFranchise"), equalTo(new ModifyRecordResult("a03B0000007BhQQIA0"))));
+
+    assertThat(
+        "the first movie was created",
+        result,
+        hasEntry(equalTo("createEp1"), equalTo(new ModifyRecordResult("a00B000000FSkioIAD"))));
+
+    assertThat(
+        "the second movie was created",
+        result,
+        hasEntry(equalTo("createEp2"), equalTo(new ModifyRecordResult("a00B000000FSkipIAD"))));
+
+    assertThat(
+        "the third movie was created",
+        result,
+        hasEntry(equalTo("createEp3"), equalTo(new ModifyRecordResult("a00B000000FSkiqIAD"))));
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
@@ -35,7 +35,7 @@ public class RestApiCompositeTest {
           "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
 
   @Test
-  public void compositeSingleCreate() throws RestApiException, IOException {
+  public void compositeSingleCreate() throws RestApiErrorsException, IOException, RestApiException {
     Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
 
     Map<String, JsonPrimitive> values = new HashMap<>();
@@ -55,7 +55,7 @@ public class RestApiCompositeTest {
   }
 
   @Test
-  public void compositeSingleQuery() throws RestApiException, IOException {
+  public void compositeSingleQuery() throws RestApiErrorsException, IOException, RestApiException {
     Map<String, RestApiRequest<QueryRecordResult>> subrequests = new HashMap<>();
     subrequests.put("query", new QueryRecordRestApiRequest("SELECT Name FROM Franchise__c"));
 
@@ -82,7 +82,7 @@ public class RestApiCompositeTest {
   }
 
   @Test
-  public void compositeSingleCreateWithError() throws IOException {
+  public void compositeSingleCreateWithError() throws IOException, RestApiException {
     Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
 
     Map<String, JsonPrimitive> values = new HashMap<>();
@@ -96,7 +96,7 @@ public class RestApiCompositeTest {
 
     try {
       restApi.execute(request);
-    } catch (RestApiException e) {
+    } catch (RestApiErrorsException e) {
       assertThat(
           "the error from the inner create request is in the error from the composite request",
           e.getApiErrors(),
@@ -113,7 +113,7 @@ public class RestApiCompositeTest {
   }
 
   @Test
-  public void compositeSingleUpdate() throws RestApiException, IOException {
+  public void compositeSingleUpdate() throws RestApiErrorsException, IOException, RestApiException {
     Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
 
     Map<String, JsonPrimitive> values = new HashMap<>();
@@ -133,7 +133,7 @@ public class RestApiCompositeTest {
   }
 
   @Test
-  public void compositeCreateTree() throws RestApiException, IOException {
+  public void compositeCreateTree() throws RestApiErrorsException, IOException, RestApiException {
     Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new LinkedHashMap<>();
 
     Map<String, JsonPrimitive> valuesFranchise = new HashMap<>();

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.gson.JsonPrimitive;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RestApiCreateTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "51.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void create() throws RestApiException, IOException {
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("Name", new JsonPrimitive("Star Wars Episode V: The Empire Strikes Back"));
+    values.put("Rating__c", new JsonPrimitive("Excellent"));
+
+    CreateRecordRestApiRequest request = new CreateRecordRestApiRequest("Movie__c", values);
+    ModifyRecordResult result = restApi.execute(request);
+    assertThat("id equals expected value", result.getId(), equalTo("a00B000000FSkcvIAD"));
+  }
+
+  @Test
+  public void createWithInvalidPicklistValue() throws IOException {
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("Name", new JsonPrimitive("Star Wars Episode VIII: The Last Jedi"));
+    values.put("Rating__c", new JsonPrimitive("Terrible"));
+
+    CreateRecordRestApiRequest request = new CreateRecordRestApiRequest("Movie__c", values);
+
+    try {
+      restApi.execute(request);
+    } catch (RestApiException e) {
+      RestApiError error = e.getApiErrors().get(0);
+
+      assertThat(
+          "The error has the correct message",
+          error.getMessage(),
+          equalTo("Rating: bad value for restricted picklist field: Terrible"));
+
+      assertThat(
+          "The error has the correct code",
+          error.getErrorCode(),
+          equalTo("INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST"));
+
+      assertThat("The error has the correct fields", error.getFields(), contains("Rating__c"));
+
+      return;
+    }
+
+    Assert.fail("Expected exception!");
+  }
+
+  @Test
+  public void createWithUnknownObjectType() throws IOException {
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("Name", new JsonPrimitive("Ace of Spades"));
+
+    CreateRecordRestApiRequest request = new CreateRecordRestApiRequest("PlayingCard__c", values);
+
+    try {
+      restApi.execute(request);
+    } catch (RestApiException e) {
+      RestApiError error = e.getApiErrors().get(0);
+
+      assertThat(
+          "The error has the correct message",
+          error.getMessage(),
+          equalTo("The requested resource does not exist"));
+
+      assertThat(
+          "The error has the correct code",
+          error.getErrorCode(),
+          equalTo("NOT_FOUND"));
+
+      assertThat("The error has the correct fields", error.getFields(), empty());
+
+      return;
+    }
+
+    Assert.fail("Expected exception!");
+  }
+
+  @Test
+  public void createWithInvalidField() throws IOException {
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("FavoritePet__c", new JsonPrimitive("Dog"));
+
+    CreateRecordRestApiRequest request = new CreateRecordRestApiRequest("Account", values);
+
+    try {
+      restApi.execute(request);
+    } catch (RestApiException e) {
+      RestApiError error = e.getApiErrors().get(0);
+
+      assertThat(
+          "The error has the correct message",
+          error.getMessage(),
+          equalTo("No such column 'FavoritePet__c' on sobject of type Account"));
+
+      assertThat(
+          "The error has the correct code",
+          error.getErrorCode(),
+          equalTo("INVALID_FIELD"));
+
+      assertThat("The error has the correct fields", error.getFields(), empty());
+
+      return;
+    }
+
+    Assert.fail("Expected exception!");
+  }
+
+  @Test
+  public void createWithRequiredFieldMissing() throws IOException {
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("Name", new JsonPrimitive("Falcon 9"));
+
+    CreateRecordRestApiRequest request = new CreateRecordRestApiRequest("Spaceship__c", values);
+
+    try {
+      restApi.execute(request);
+    } catch (RestApiException e) {
+      RestApiError error = e.getApiErrors().get(0);
+
+      assertThat(
+          "The error has the correct message",
+          error.getMessage(),
+          equalTo("Required fields are missing: [Website__c]"));
+
+      assertThat(
+          "The error has the correct code",
+          error.getErrorCode(),
+          equalTo("REQUIRED_FIELD_MISSING"));
+
+      assertThat("The error has the correct fields", error.getFields(), contains("Website__c"));
+
+      return;
+    }
+
+    Assert.fail("Expected exception!");
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
@@ -31,7 +31,7 @@ public class RestApiCreateTest {
           "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
 
   @Test
-  public void create() throws RestApiException, IOException {
+  public void create() throws RestApiErrorsException, IOException, RestApiException {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Star Wars Episode V: The Empire Strikes Back"));
     values.put("Rating__c", new JsonPrimitive("Excellent"));
@@ -42,7 +42,7 @@ public class RestApiCreateTest {
   }
 
   @Test
-  public void createWithInvalidPicklistValue() throws IOException {
+  public void createWithInvalidPicklistValue() throws IOException, RestApiException {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Star Wars Episode VIII: The Last Jedi"));
     values.put("Rating__c", new JsonPrimitive("Terrible"));
@@ -51,7 +51,7 @@ public class RestApiCreateTest {
 
     try {
       restApi.execute(request);
-    } catch (RestApiException e) {
+    } catch (RestApiErrorsException e) {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(
@@ -73,7 +73,7 @@ public class RestApiCreateTest {
   }
 
   @Test
-  public void createWithUnknownObjectType() throws IOException {
+  public void createWithUnknownObjectType() throws IOException, RestApiException {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Ace of Spades"));
 
@@ -81,7 +81,7 @@ public class RestApiCreateTest {
 
     try {
       restApi.execute(request);
-    } catch (RestApiException e) {
+    } catch (RestApiErrorsException e) {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(
@@ -100,7 +100,7 @@ public class RestApiCreateTest {
   }
 
   @Test
-  public void createWithInvalidField() throws IOException {
+  public void createWithInvalidField() throws IOException, RestApiException {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("FavoritePet__c", new JsonPrimitive("Dog"));
 
@@ -108,7 +108,7 @@ public class RestApiCreateTest {
 
     try {
       restApi.execute(request);
-    } catch (RestApiException e) {
+    } catch (RestApiErrorsException e) {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(
@@ -127,7 +127,7 @@ public class RestApiCreateTest {
   }
 
   @Test
-  public void createWithRequiredFieldMissing() throws IOException {
+  public void createWithRequiredFieldMissing() throws IOException, RestApiException {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Falcon 9"));
 
@@ -135,7 +135,7 @@ public class RestApiCreateTest {
 
     try {
       restApi.execute(request);
-    } catch (RestApiException e) {
+    } catch (RestApiErrorsException e) {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
@@ -89,10 +89,7 @@ public class RestApiCreateTest {
           error.getMessage(),
           equalTo("The requested resource does not exist"));
 
-      assertThat(
-          "The error has the correct code",
-          error.getErrorCode(),
-          equalTo("NOT_FOUND"));
+      assertThat("The error has the correct code", error.getErrorCode(), equalTo("NOT_FOUND"));
 
       assertThat("The error has the correct fields", error.getFields(), empty());
 
@@ -119,10 +116,7 @@ public class RestApiCreateTest {
           error.getMessage(),
           equalTo("No such column 'FavoritePet__c' on sobject of type Account"));
 
-      assertThat(
-          "The error has the correct code",
-          error.getErrorCode(),
-          equalTo("INVALID_FIELD"));
+      assertThat("The error has the correct code", error.getErrorCode(), equalTo("INVALID_FIELD"));
 
       assertThat("The error has the correct fields", error.getFields(), empty());
 

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiErrorTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiErrorTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class RestApiErrorTest {
+
+  @Test
+  public void name() {
+    EqualsVerifier.forClass(RestApiError.class).verify();
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiErrorTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiErrorTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 public class RestApiErrorTest {
 
   @Test
-  public void name() {
+  public void testEqualsAndHashCode() {
     EqualsVerifier.forClass(RestApiError.class).verify();
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
@@ -32,7 +32,8 @@ public class RestApiQueryTest {
           "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
 
   @Test
-  public void queryWithNextRecordsUrl() throws IOException, RestApiException {
+  public void queryWithNextRecordsUrl()
+      throws IOException, RestApiErrorsException, RestApiException {
     QueryRecordRestApiRequest queryRequest =
         new QueryRecordRestApiRequest("SELECT RANDOM_1__c, RANDOM_2__c FROM Random__c");
     QueryRecordResult result = restApi.execute(queryRequest);
@@ -46,7 +47,7 @@ public class RestApiQueryTest {
   }
 
   @Test
-  public void queryMoreRecords() throws IOException, RestApiException {
+  public void queryMoreRecords() throws IOException, RestApiErrorsException, RestApiException {
     QueryRecordRestApiRequest queryRequest =
         new QueryRecordRestApiRequest("SELECT RANDOM_1__c, RANDOM_2__c FROM Random__c");
     QueryRecordResult result = restApi.execute(queryRequest);
@@ -59,13 +60,13 @@ public class RestApiQueryTest {
   }
 
   @Test
-  public void queryWithUnknownColumn() throws IOException {
+  public void queryWithUnknownColumn() throws IOException, RestApiException {
     QueryRecordRestApiRequest queryRequest =
         new QueryRecordRestApiRequest("SELECT Bacon__c FROM Account LIMIT 2");
 
     try {
       restApi.execute(queryRequest);
-    } catch (RestApiException e) {
+    } catch (RestApiErrorsException e) {
       assertThat("Exactly one error is returned", e.getApiErrors().size(), is(1));
 
       RestApiError apiError = e.getApiErrors().get(0);
@@ -85,13 +86,13 @@ public class RestApiQueryTest {
   }
 
   @Test
-  public void queryWithMalformedSoql() throws IOException {
+  public void queryWithMalformedSoql() throws IOException, RestApiException {
     QueryRecordRestApiRequest queryRequest =
         new QueryRecordRestApiRequest("SELEKT Name FROM Account");
 
     try {
       restApi.execute(queryRequest);
-    } catch (RestApiException e) {
+    } catch (RestApiErrorsException e) {
       assertThat("Exactly one error is returned", e.getApiErrors().size(), is(1));
 
       RestApiError apiError = e.getApiErrors().get(0);
@@ -110,7 +111,7 @@ public class RestApiQueryTest {
   }
 
   @Test
-  public void queryAccountNames() throws IOException, RestApiException {
+  public void queryAccountNames() throws IOException, RestApiErrorsException, RestApiException {
     QueryRecordRestApiRequest queryRequest =
         new QueryRecordRestApiRequest("SELECT Name FROM Account");
     QueryRecordResult result = restApi.execute(queryRequest);

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
@@ -6,18 +6,17 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
+import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.gson.JsonPrimitive;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.Tuple;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -157,47 +156,5 @@ public class RestApiQueryTest {
             map(new Tuple("Name", "Sample Account for Entitlements"))));
 
     assertThat("records match", result.getRecords(), equalTo(expectedRecords));
-  }
-
-  private static Map<String, JsonPrimitive> map(Tuple... data) {
-    HashMap<String, JsonPrimitive> result = new HashMap<>();
-    for (Tuple tuple : data) {
-      result.put(tuple.getKey(), tuple.getValue());
-    }
-
-    return result;
-  }
-
-  private static class Tuple {
-    private final String key;
-    private final JsonPrimitive value;
-
-    public Tuple(String key, String value) {
-      this.key = key;
-      this.value = new JsonPrimitive(value);
-    }
-
-    public Tuple(String key, Number value) {
-      this.key = key;
-      this.value = new JsonPrimitive(value);
-    }
-
-    public Tuple(String key, Boolean value) {
-      this.key = key;
-      this.value = new JsonPrimitive(value);
-    }
-
-    public Tuple(String key, Character value) {
-      this.key = key;
-      this.value = new JsonPrimitive(value);
-    }
-
-    public String getKey() {
-      return key;
-    }
-
-    public JsonPrimitive getValue() {
-      return value;
-    }
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.net.URI;
+import org.junit.Test;
+
+public class RestApiTest {
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "51.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void testApiVersionGetter() {
+    assertThat(
+        "getApiVersion returns the correct API version", restApi.getApiVersion(), equalTo("51.0"));
+  }
+
+  @Test
+  public void testAccessTokenGetter() {
+    assertThat(
+        "getAccessToken returns the correct access token",
+        restApi.getAccessToken(),
+        equalTo(
+            "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"));
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
@@ -9,15 +9,40 @@ package com.salesforce.functions.jvm.runtime.sdk.restapi;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.IOException;
 import java.net.URI;
+import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class RestApiTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
   private final RestApi restApi =
       new RestApi(
           URI.create("http://localhost:8080/"),
           "51.0",
           "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void testUnexpectedResponse() throws IOException, RestApiErrorsException {
+    QueryRecordRestApiRequest queryRequest =
+        new QueryRecordRestApiRequest("SELECT Name FROM FruitVendor__c");
+
+    try {
+      restApi.execute(queryRequest);
+    } catch (RestApiException e) {
+      assertThat(
+          "the exception message is matching the error",
+          e.getMessage(),
+          equalTo("Could not parse API response as JSON!"));
+
+      return;
+    }
+
+    Assert.fail("Expected Exception!");
+  }
 
   @Test
   public void testApiVersionGetter() {

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.gson.JsonPrimitive;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RestApiUpdateTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "51.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void update() throws RestApiException, IOException {
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
+
+    UpdateRecordRestApiRequest request = new UpdateRecordRestApiRequest("a00B000000FSjVUIA1", "Movie__c", values);
+    ModifyRecordResult result = restApi.execute(request);
+    assertThat("id equals expected value", result.getId(), equalTo("a00B000000FSjVUIA1"));
+  }
+
+  @Test
+  public void updateWithMalformedId() throws RestApiException, IOException {
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
+
+    UpdateRecordRestApiRequest request = new UpdateRecordRestApiRequest("a00B000000FSjVUIB1", "Movie__c", values);
+
+    try {
+      restApi.execute(request);
+    } catch (RestApiException e) {
+      RestApiError error = e.getApiErrors().get(0);
+
+      assertThat(
+          "The error has the correct message",
+          error.getMessage(),
+          equalTo("Record ID: id value of incorrect type: a00B000000FSjVUIB1"));
+
+      assertThat(
+          "The error has the correct code",
+          error.getErrorCode(),
+          equalTo("MALFORMED_ID"));
+
+      assertThat("The error has the correct fields", error.getFields(), contains("Id"));
+
+      return;
+    }
+
+    Assert.fail("Expected exception!");
+  }
+
+
+  @Test
+  public void updateWithInvalidField() throws RestApiException, IOException {
+    Map<String, JsonPrimitive> values = new HashMap<>();
+    values.put("Color__c", new JsonPrimitive("Red"));
+
+    UpdateRecordRestApiRequest request = new UpdateRecordRestApiRequest("a00B000000FSjVUIB1", "Movie__c", values);
+
+    try {
+      restApi.execute(request);
+    } catch (RestApiException e) {
+      RestApiError error = e.getApiErrors().get(0);
+
+      assertThat(
+          "The error has the correct message",
+          error.getMessage(),
+          equalTo("No such column 'Color__c' on sobject of type Movie__c"));
+
+      assertThat(
+          "The error has the correct code",
+          error.getErrorCode(),
+          equalTo("INVALID_FIELD"));
+
+      assertThat("The error has the correct fields", error.getFields(), empty());
+
+      return;
+    }
+
+    Assert.fail("Expected exception!");
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
@@ -31,7 +31,7 @@ public class RestApiUpdateTest {
           "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
 
   @Test
-  public void update() throws RestApiException, IOException {
+  public void update() throws RestApiErrorsException, IOException, RestApiException {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
 
@@ -42,7 +42,7 @@ public class RestApiUpdateTest {
   }
 
   @Test
-  public void updateWithMalformedId() throws RestApiException, IOException {
+  public void updateWithMalformedId() throws IOException, RestApiException {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
 
@@ -51,7 +51,7 @@ public class RestApiUpdateTest {
 
     try {
       restApi.execute(request);
-    } catch (RestApiException e) {
+    } catch (RestApiErrorsException e) {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(
@@ -70,7 +70,7 @@ public class RestApiUpdateTest {
   }
 
   @Test
-  public void updateWithInvalidField() throws RestApiException, IOException {
+  public void updateWithInvalidField() throws IOException, RestApiException {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("Color__c", new JsonPrimitive("Red"));
 
@@ -79,7 +79,7 @@ public class RestApiUpdateTest {
 
     try {
       restApi.execute(request);
-    } catch (RestApiException e) {
+    } catch (RestApiErrorsException e) {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
@@ -35,7 +35,8 @@ public class RestApiUpdateTest {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
 
-    UpdateRecordRestApiRequest request = new UpdateRecordRestApiRequest("a00B000000FSjVUIA1", "Movie__c", values);
+    UpdateRecordRestApiRequest request =
+        new UpdateRecordRestApiRequest("a00B000000FSjVUIA1", "Movie__c", values);
     ModifyRecordResult result = restApi.execute(request);
     assertThat("id equals expected value", result.getId(), equalTo("a00B000000FSjVUIA1"));
   }
@@ -45,7 +46,8 @@ public class RestApiUpdateTest {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
 
-    UpdateRecordRestApiRequest request = new UpdateRecordRestApiRequest("a00B000000FSjVUIB1", "Movie__c", values);
+    UpdateRecordRestApiRequest request =
+        new UpdateRecordRestApiRequest("a00B000000FSjVUIB1", "Movie__c", values);
 
     try {
       restApi.execute(request);
@@ -57,10 +59,7 @@ public class RestApiUpdateTest {
           error.getMessage(),
           equalTo("Record ID: id value of incorrect type: a00B000000FSjVUIB1"));
 
-      assertThat(
-          "The error has the correct code",
-          error.getErrorCode(),
-          equalTo("MALFORMED_ID"));
+      assertThat("The error has the correct code", error.getErrorCode(), equalTo("MALFORMED_ID"));
 
       assertThat("The error has the correct fields", error.getFields(), contains("Id"));
 
@@ -70,13 +69,13 @@ public class RestApiUpdateTest {
     Assert.fail("Expected exception!");
   }
 
-
   @Test
   public void updateWithInvalidField() throws RestApiException, IOException {
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("Color__c", new JsonPrimitive("Red"));
 
-    UpdateRecordRestApiRequest request = new UpdateRecordRestApiRequest("a00B000000FSjVUIB1", "Movie__c", values);
+    UpdateRecordRestApiRequest request =
+        new UpdateRecordRestApiRequest("a00B000000FSjVUIB1", "Movie__c", values);
 
     try {
       restApi.execute(request);
@@ -88,10 +87,7 @@ public class RestApiUpdateTest {
           error.getMessage(),
           equalTo("No such column 'Color__c' on sobject of type Movie__c"));
 
-      assertThat(
-          "The error has the correct code",
-          error.getErrorCode(),
-          equalTo("INVALID_FIELD"));
+      assertThat("The error has the correct code", error.getErrorCode(), equalTo("INVALID_FIELD"));
 
       assertThat("The error has the correct fields", error.getFields(), empty());
 

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-create-tree.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-create-tree.json
@@ -1,0 +1,42 @@
+{
+  "id": "ec342b92-e7ce-4360-a529-d8bb4380aaee",
+  "name": "services_data_v510_composite",
+  "request": {
+    "url": "/services/data/v51.0/composite",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"allOrNone\": true,\n    \"compositeRequest\": [{\n        \"url\": \"services/data/v51.0/sobjects/Franchise__c\",\n        \"method\": \"POST\",\n        \"referenceId\": \"createFranchise\",\n        \"body\": {\n            \"Name\": \"Star Wars\"\n        }\n    },{\n        \"url\": \"services/data/v51.0/sobjects/Movie__c\",\n        \"method\": \"POST\",\n        \"referenceId\": \"createEp1\",\n        \"body\": {\n            \"Name\": \"Star Wars Episode I - A Phantom Menace\",\n            \"Franchise__c\": \"@{createFranchise.id}\"\n        }\n    },{\n        \"url\": \"services/data/v51.0/sobjects/Movie__c\",\n        \"method\": \"POST\",\n        \"referenceId\": \"createEp2\",\n        \"body\": {\n            \"Name\": \"Star Wars Episode II - Attack Of The Clones\",\n            \"Franchise__c\": \"@{createFranchise.id}\"\n        }\n    },{\n        \"url\": \"services/data/v51.0/sobjects/Movie__c\",\n        \"method\": \"POST\",\n        \"referenceId\": \"createEp3\",\n        \"body\": {\n            \"Name\": \"Star Wars Episode III - Revenge Of The Sith\",\n            \"Franchise__c\": \"@{createFranchise.id}\"\n        }\n    }]\n}",
+        "ignoreArrayOrder": false,
+        "ignoreExtraElements": false
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"compositeResponse\":[{\"body\":{\"id\":\"a03B0000007BhQQIA0\",\"success\":true,\"errors\":[]},\"httpHeaders\":{\"Location\":\"/services/data/v51.0/sobjects/Franchise__c/a03B0000007BhQQIA0\"},\"httpStatusCode\":201,\"referenceId\":\"createFranchise\"},{\"body\":{\"id\":\"a00B000000FSkioIAD\",\"success\":true,\"errors\":[]},\"httpHeaders\":{\"Location\":\"/services/data/v51.0/sobjects/Movie__c/a00B000000FSkioIAD\"},\"httpStatusCode\":201,\"referenceId\":\"createEp1\"},{\"body\":{\"id\":\"a00B000000FSkipIAD\",\"success\":true,\"errors\":[]},\"httpHeaders\":{\"Location\":\"/services/data/v51.0/sobjects/Movie__c/a00B000000FSkipIAD\"},\"httpStatusCode\":201,\"referenceId\":\"createEp2\"},{\"body\":{\"id\":\"a00B000000FSkiqIAD\",\"success\":true,\"errors\":[]},\"httpHeaders\":{\"Location\":\"/services/data/v51.0/sobjects/Movie__c/a00B000000FSkiqIAD\"},\"httpStatusCode\":201,\"referenceId\":\"createEp3\"}]}",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 15:49:22 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=-1h2cJ04EeuwV6vmZAk38w; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:49:22 GMT; Max-Age=31536000",
+        "BrowserId_sec=-1h2cJ04EeuwV6vmZAk38w; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:49:22 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=97/100000",
+      "Content-Type": "application/json;charset=UTF-8",
+      "Vary": "Accept-Encoding"
+    }
+  },
+  "uuid": "ec342b92-e7ce-4360-a529-d8bb4380aaee",
+  "persistent": true,
+  "insertionIndex": 47
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-create-error.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-create-error.json
@@ -1,0 +1,42 @@
+{
+  "id": "f1aa5280-2f57-4918-a4d1-6a01b554a77d",
+  "name": "services_data_v510_composite",
+  "request": {
+    "url": "/services/data/v51.0/composite",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"allOrNone\": true,\n    \"compositeRequest\": [{\n        \"url\": \"services/data/v51.0/sobjects/Movie__c\",\n        \"method\": \"POST\",\n        \"referenceId\": \"insert-anh\",\n        \"body\": {\n            \"Name\": \"Star Wars Episode IV - A New Hope\",\n            \"Rating__c\": \"Amazing\"\n        }\n    }]\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": false
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"compositeResponse\":[{\"body\":[{\"message\":\"Rating: bad value for restricted picklist field: Amazing\",\"errorCode\":\"INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST\",\"fields\":[\"Rating__c\"]}],\"httpHeaders\":{},\"httpStatusCode\":400,\"referenceId\":\"insert-anh\"}]}",
+    "headers": {
+      "Date": "Thu, 15 Apr 2021 08:38:40 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=-nSqXZ3FEeuU4h0mKdEQ6w; domain=.salesforce.com; path=/; expires=Fri, 15-Apr-2022 08:38:40 GMT; Max-Age=31536000",
+        "BrowserId_sec=-nSqXZ3FEeuU4h0mKdEQ6w; domain=.salesforce.com; path=/; expires=Fri, 15-Apr-2022 08:38:40 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=69/100000",
+      "Content-Type": "application/json;charset=UTF-8",
+      "Vary": "Accept-Encoding"
+    }
+  },
+  "uuid": "f1aa5280-2f57-4918-a4d1-6a01b554a77d",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-create.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-create.json
@@ -1,0 +1,42 @@
+{
+  "id": "fcc870b2-acd9-4b45-b101-f125b26091b3",
+  "name": "services_data_v510_composite",
+  "request": {
+    "url": "/services/data/v51.0/composite",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"allOrNone\": true,\n    \"compositeRequest\": [{\n        \"url\": \"services/data/v51.0/sobjects/Movie__c\",\n        \"method\": \"POST\",\n        \"referenceId\": \"insert-anh\",\n        \"body\": {\n            \"Name\": \"Star Wars Episode IV - A New Hope\",\n            \"Rating__c\": \"Excellent\"\n        }\n    }]\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": false
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"compositeResponse\":[{\"body\":{\"id\":\"a00B000000FSkgxIAD\",\"success\":true,\"errors\":[]},\"httpHeaders\":{\"Location\":\"/services/data/v51.0/sobjects/Movie__c/a00B000000FSkgxIAD\"},\"httpStatusCode\":201,\"referenceId\":\"insert-anh\"}]}",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 15:18:53 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=uRmtjp00Eeu_d6Wc93GdsA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:18:53 GMT; Max-Age=31536000",
+        "BrowserId_sec=uRmtjp00Eeu_d6Wc93GdsA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:18:53 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=77/100000",
+      "Content-Type": "application/json;charset=UTF-8",
+      "Vary": "Accept-Encoding"
+    }
+  },
+  "uuid": "fcc870b2-acd9-4b45-b101-f125b26091b3",
+  "persistent": true,
+  "insertionIndex": 35
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-query.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-query.json
@@ -1,0 +1,42 @@
+{
+  "id": "0223dfaf-3947-43ec-9afa-52247d959ede",
+  "name": "services_data_v510_composite",
+  "request": {
+    "url": "/services/data/v51.0/composite",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"allOrNone\": true,\n    \"compositeRequest\": [{\n        \"url\": \"services/data/v51.0/query?q=SELECT+Name+FROM+Franchise__c\",\n        \"method\": \"GET\",\n        \"referenceId\": \"query\"\n    }]\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": false
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\n    \"compositeResponse\": [\n        {\n            \"body\": {\n                \"totalSize\": 1,\n                \"done\": true,\n                \"records\": [\n                    {\n                        \"attributes\": {\n                            \"type\": \"Franchise__c\",\n                            \"url\": \"/services/data/v51.0/sobjects/Franchise__c/a03B0000007BhQVIA0\"\n                        },\n                        \"Name\": \"Star Wars\"\n                    }\n                ]\n            },\n            \"httpHeaders\": {},\n            \"httpStatusCode\": 200,\n            \"referenceId\": \"query\"\n        }\n    ]\n}",
+    "headers": {
+      "Date": "Thu, 15 Apr 2021 11:43:03 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=vIvTtJ3fEeuq1W3pYQ9osQ; domain=.salesforce.com; path=/; expires=Fri, 15-Apr-2022 11:43:03 GMT; Max-Age=31536000",
+        "BrowserId_sec=vIvTtJ3fEeuq1W3pYQ9osQ; domain=.salesforce.com; path=/; expires=Fri, 15-Apr-2022 11:43:03 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=17/100000",
+      "Content-Type": "application/json;charset=UTF-8",
+      "Vary": "Accept-Encoding"
+    }
+  },
+  "uuid": "0223dfaf-3947-43ec-9afa-52247d959ede",
+  "persistent": true,
+  "insertionIndex": 9
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-update.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-update.json
@@ -1,0 +1,42 @@
+{
+  "id": "5a1998f7-e41e-4421-9297-5ca7ba533aff",
+  "name": "services_data_v510_composite",
+  "request": {
+    "url": "/services/data/v51.0/composite",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"allOrNone\": true,\n    \"compositeRequest\": [{\n        \"url\": \"services/data/v51.0/sobjects/Movie__c/a00B000000FSjVUIA1\",\n        \"method\": \"PATCH\",\n        \"referenceId\": \"update-esb\",\n        \"body\": {\n            \"ReleaseDate__c\": \"1980-05-21\"\n        }\n    }]\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": false
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"compositeResponse\":[{\"body\":null,\"httpHeaders\":{},\"httpStatusCode\":204,\"referenceId\":\"update-esb\"}]}",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 15:36:33 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=MNhckp03EeuDm6MXHUvRMQ; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:36:33 GMT; Max-Age=31536000",
+        "BrowserId_sec=MNhckp03EeuDm6MXHUvRMQ; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:36:33 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=90/100000",
+      "Content-Type": "application/json;charset=UTF-8",
+      "Vary": "Accept-Encoding"
+    }
+  },
+  "uuid": "5a1998f7-e41e-4421-9297-5ca7ba533aff",
+  "persistent": true,
+  "insertionIndex": 37
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-invalid-field.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-invalid-field.json
@@ -1,0 +1,41 @@
+{
+  "id": "4423cb35-8e3f-49b5-a5b4-5107d627e208",
+  "name": "services_data_v510_sobjects_account",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/Account",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"FavoritePet__c\": \"Dog\"\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "body": "[{\"message\":\"No such column 'FavoritePet__c' on sobject of type Account\",\"errorCode\":\"INVALID_FIELD\"}]",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 14:35:57 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=ueTUG50uEeunvSe3LV7u5w; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 14:35:57 GMT; Max-Age=31536000",
+        "BrowserId_sec=ueTUG50uEeunvSe3LV7u5w; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 14:35:57 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=60/100000",
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "4423cb35-8e3f-49b5-a5b4-5107d627e208",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-invalid-picklist-value.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-invalid-picklist-value.json
@@ -1,0 +1,41 @@
+{
+  "id": "789ffdd0-0697-4805-adb4-6df04d0f9fcb",
+  "name": "services_data_v510_sobjects_movie__c",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/Movie__c",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"Name\": \"Star Wars Episode VIII: The Last Jedi\",\n    \"Rating__c\": \"Terrible\"\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "body": "[{\"message\":\"Rating: bad value for restricted picklist field: Terrible\",\"errorCode\":\"INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST\",\"fields\":[\"Rating__c\"]}]",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 13:59:24 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=nrZ3CJ0pEeuSsu_WRTJspA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 13:59:24 GMT; Max-Age=31536000",
+        "BrowserId_sec=nrZ3CJ0pEeuSsu_WRTJspA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 13:59:24 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=56/100000",
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "789ffdd0-0697-4805-adb4-6df04d0f9fcb",
+  "persistent": true,
+  "insertionIndex": 6
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-required-field-missing.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-required-field-missing.json
@@ -1,0 +1,41 @@
+{
+  "id": "20efd3ef-3b3a-4c68-9bde-6d42ed3e0554",
+  "name": "services_data_v510_sobjects_spaceship__c",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/Spaceship__c",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"Name\": \"Falcon 9\"\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "body": "[{\"message\":\"Required fields are missing: [Website__c]\",\"errorCode\":\"REQUIRED_FIELD_MISSING\",\"fields\":[\"Website__c\"]}]",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 14:42:02 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=kwVk3J0vEeuXIYcIj-H-nA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 14:42:02 GMT; Max-Age=31536000",
+        "BrowserId_sec=kwVk3J0vEeuXIYcIj-H-nA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 14:42:02 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=61/100000",
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "20efd3ef-3b3a-4c68-9bde-6d42ed3e0554",
+  "persistent": true,
+  "insertionIndex": 1
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-unknown-object.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-unknown-object.json
@@ -1,0 +1,41 @@
+{
+  "id": "31a0631a-8930-44b6-b990-89a3cc1c6f75",
+  "name": "services_data_v510_sobjects_playingcard__c",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/PlayingCard__c",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"Name\": \"Ace of Spades\"\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 404,
+    "body": "[{\"errorCode\":\"NOT_FOUND\",\"message\":\"The requested resource does not exist\"}]",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 14:12:58 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=g_r6aZ0rEeuXIYcIj-H-nA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 14:12:58 GMT; Max-Age=31536000",
+        "BrowserId_sec=g_r6aZ0rEeuXIYcIj-H-nA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 14:12:58 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=59/100000",
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "31a0631a-8930-44b6-b990-89a3cc1c6f75",
+  "persistent": true,
+  "insertionIndex": 1
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create.json
@@ -1,0 +1,43 @@
+{
+  "id": "de18b82b-5dcc-4eea-9b2a-cf5973282031",
+  "name": "services_data_v510_sobjects_movie__c",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/Movie__c",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"Name\": \"Star Wars Episode V: The Empire Strikes Back\",\n    \"Rating__c\": \"Excellent\"\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 201,
+    "body": "{\"id\":\"a00B000000FSkcvIAD\",\"success\":true,\"errors\":[]}",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 13:50:54 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=bmg9450oEeuFnSMDERhUCg; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 13:50:54 GMT; Max-Age=31536000",
+        "BrowserId_sec=bmg9450oEeuFnSMDERhUCg; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 13:50:54 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=51/100000",
+      "Location": "/services/data/v51.0/sobjects/Movie__c/a00B000000FSkcvIAD",
+      "Content-Type": "application/json;charset=UTF-8",
+      "Vary": "Accept-Encoding"
+    }
+  },
+  "uuid": "de18b82b-5dcc-4eea-9b2a-cf5973282031",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-unexpected-response.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-unexpected-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "b843b8c1-6492-4048-90d5-08d6f90cb739",
+  "name": "services_data_v510_query",
+  "request": {
+    "urlPath": "/services/data/v51.0/query",
+    "method": "GET",
+    "queryParameters" : {
+      "q": {
+        "equalTo": "SELECT Name FROM FruitVendor__c"
+      }
+    },
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 404,
+    "body": "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system, system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color: #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n    <p>This domain is for use in illustrative examples in documents. You may use this\n    domain in literature without prior coordination or asking for permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More information...</a></p>\n</div>\n</body>\n</html>\n",
+    "headers": {
+      "Age": "63",
+      "Cache-Control": "max-age=604800",
+      "Content-Type": "text/html; charset=UTF-8",
+      "Date": "Thu, 15 Apr 2021 12:04:45 GMT",
+      "Expires": "Thu, 22 Apr 2021 12:04:45 GMT",
+      "Last-Modified": "Thu, 15 Apr 2021 12:03:42 GMT",
+      "Server": "ECS (oxr/8314)",
+      "Vary": "Accept-Encoding",
+      "X-Cache": "404-HIT"
+    }
+  },
+  "uuid": "b843b8c1-6492-4048-90d5-08d6f90cb739",
+  "persistent": true,
+  "insertionIndex": 7
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update-invalid-field.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update-invalid-field.json
@@ -1,0 +1,41 @@
+{
+  "id": "1a29d823-5272-4e2b-9774-d7ac4a3a07bb",
+  "name": "services_data_v510_sobjects_movie__c_a00b000000fsjvuib1",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/Movie__c/a00B000000FSjVUIB1",
+    "method": "PATCH",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"Color__c\": \"Red\"\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "body": "[{\"message\":\"No such column 'Color__c' on sobject of type Movie__c\",\"errorCode\":\"INVALID_FIELD\"}]",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 15:09:12 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=XpBzV50zEeus9UFn2XQEsg; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:09:12 GMT; Max-Age=31536000",
+        "BrowserId_sec=XpBzV50zEeus9UFn2XQEsg; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:09:12 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=74/100000",
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "1a29d823-5272-4e2b-9774-d7ac4a3a07bb",
+  "persistent": true,
+  "insertionIndex": 17
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update-malformed-id.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update-malformed-id.json
@@ -1,0 +1,41 @@
+{
+  "id": "b78f181e-8308-4fd7-8fd2-4b3cfb4cdcef",
+  "name": "services_data_v510_sobjects_movie__c_a00b000000fsjvuib1",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/Movie__c/a00B000000FSjVUIB1",
+    "method": "PATCH",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"ReleaseDate__c\": \"1980-05-21\"\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "body": "[{\"message\":\"Record ID: id value of incorrect type: a00B000000FSjVUIB1\",\"errorCode\":\"MALFORMED_ID\",\"fields\":[\"Id\"]}]",
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 15:06:13 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=894AB50yEeuWMeeWLri-UA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:06:13 GMT; Max-Age=31536000",
+        "BrowserId_sec=894AB50yEeuWMeeWLri-UA; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:06:13 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=72/100000",
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "b78f181e-8308-4fd7-8fd2-4b3cfb4cdcef",
+  "persistent": true,
+  "insertionIndex": 15
+}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update.json
@@ -1,0 +1,41 @@
+{
+  "id": "d8405304-0f8e-43db-bc9a-25bcaf7632da",
+  "name": "services_data_v510_sobjects_movie__c_a00b000000fsjvuia1",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/Movie__c/a00B000000FSjVUIA1",
+    "method": "PATCH",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"ReleaseDate__c\": \"1980-05-21\"\n}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      }
+    }
+  },
+  "response": {
+    "status": 204,
+    "headers": {
+      "Date": "Wed, 14 Apr 2021 15:03:08 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "Content-Security-Policy-Report-Only": "default-src https:; script-src https: 'unsafe-inline' 'unsafe-eval'; style-src https: 'unsafe-inline'; img-src https: data: blob: file:; frame-ancestors 'self' *.salesforce.com *.force.com *.visualforce.com *.documentforce.com; font-src https: data: blob: file:; connect-src 'self' https:; report-uri https://csp-report.force.com/_/ContentDomainCSPNoAuth?type=mydomain",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "Content-Security-Policy": "upgrade-insecure-requests",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=ha_5050yEeucTLOGbgUKaw; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:03:08 GMT; Max-Age=31536000",
+        "BrowserId_sec=ha_5050yEeucTLOGbgUKaw; domain=.salesforce.com; path=/; expires=Thu, 14-Apr-2022 15:03:08 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=68/100000"
+    }
+  },
+  "uuid": "d8405304-0f8e-43db-bc9a-25bcaf7632da",
+  "persistent": true,
+  "insertionIndex": 9
+}


### PR DESCRIPTION
Continues the effort started in #45.

- Add unit tests for create operations
- Add unit tests for update operations
- Add unit tests for composite operations
- Add unit test for `RestApi` methods that don't use the Salesforce REST API
- Add handling for non-JSON responses (for example HTML error pages by proxies)
- Moved URISyntaxException handling to simplify testing

References [W-9041808](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000008sXgYAI/view)
References [W-9123581](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000AbtAYAS/view)