### PR TITLE
Add Sforce-Call-Options HTTP header for client identification

### DIFF
--- a/sf-fx-runtime-java-sdk-impl-v0/pom.xml
+++ b/sf-fx-runtime-java-sdk-impl-v0/pom.xml
@@ -53,6 +53,12 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/sf-fx-runtime-java-sdk-impl-v0/src/main/resources/sf-fx-runtime-java-sdk-impl.properties
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/main/resources/sf-fx-runtime-java-sdk-impl.properties
@@ -1,0 +1,1 @@
+version=${pom.version}

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-create-tree.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-create-tree.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-create-error.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-create-error.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-create.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-create.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-delete.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-delete.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-query.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-query.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-update.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/composite-single-update.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-invalid-field.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-invalid-field.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-invalid-picklist-value.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-invalid-picklist-value.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-required-field-missing.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-required-field-missing.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-unknown-object.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create-unknown-object.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/create.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/delete-already-deleted.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/delete-already-deleted.json
@@ -7,6 +7,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/delete.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/delete.json
@@ -7,6 +7,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-malformed-soql.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-malformed-soql.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-unexpected-response.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-unexpected-response.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-unknown-column.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-unknown-column.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-with-next-records-url-2.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-with-next-records-url-2.json
@@ -7,6 +7,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-with-next-records-url.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query-with-next-records-url.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/query.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update-invalid-field.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update-invalid-field.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update-malformed-id.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update-malformed-id.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update.json
+++ b/sf-fx-runtime-java-sdk-impl-v0/src/test/resources/mappings/update.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },


### PR DESCRIPTION
Adds a `sf-fx-runtime-java-sdk-impl.properties` file that is available at runtime that contains the current version. The version is written to the file during the Maven build process using [resource filtering](https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html).

The `RestApi` client reads that file at runtime and includes [the standard `Sforce-Call-Options` HTTP header](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_calloptions.htm) with the client name and version for client identification.

WireMock stubs have been updated to expect this header for every request.

Closes [W-9019957](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008xjlrIAA/view)