### PR TITLE
Assemble JAR files during compile instead of package

### DIFF
--- a/sf-fx-runtime-java-logger/pom.xml
+++ b/sf-fx-runtime-java-logger/pom.xml
@@ -23,7 +23,9 @@
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <!-- We need to package this during compile since other modules depend on the jar-with-dependencies
+            classifier as this module is included as a JAR file instead of class files. -->
+            <phase>compile</phase>
             <goals>
               <goal>single</goal>
             </goals>

--- a/sf-fx-runtime-java-sdk-impl-v1/pom.xml
+++ b/sf-fx-runtime-java-sdk-impl-v1/pom.xml
@@ -64,7 +64,9 @@
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <!-- We need to package this during compile since other modules depend on the jar-with-dependencies
+            classifier as this module is included as a JAR file instead of class files. -->
+            <phase>compile</phase>
             <goals>
               <goal>single</goal>
             </goals>


### PR DESCRIPTION
`sf-fx-runtime-java-logger` and `sf-fx-runtime-java-sdk-impl-v1` are pulled in as JAR files by the runtime. Previously, the JAR files were only assembled during the package phase. This resulted in failed builds when the package phase was not involved in the build. This happend for example when only running the test phase.

Closes [W-9272920](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000LrT5YAK/view)