### PR TITLE
Fix HTTP status code for requests to unknown paths

### DIFF
--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/UndertowInvocationInterface.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/UndertowInvocationInterface.java
@@ -97,7 +97,7 @@ public class UndertowInvocationInterface
       if (!exchange.getRequestPath().equals("/")) {
         makeResponse(
             exchange,
-            StatusCodes.METHOD_NOT_ALLOWED,
+            StatusCodes.NOT_FOUND,
             new JsonPrimitive("HTTP 404: Not Found"),
             new ExtraInfo());
         return;


### PR DESCRIPTION
The runtime returned HTTP `405` instead of `404` for unknown paths.

Closes [W-9272917](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000LrSvYAK/view)