### PR TITLE
Fix exception handling in Slf4j1MdcDataInvocationWrapper

### DIFF
--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/Slf4j1MdcDataInvocationWrapper.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/Slf4j1MdcDataInvocationWrapper.java
@@ -64,7 +64,7 @@ public class Slf4j1MdcDataInvocationWrapper implements InvocationWrapper {
       try {
         mdcClearMethod.invoke(null);
       } catch (IllegalAccessException | InvocationTargetException e) {
-        e.printStackTrace();
+        LOGGER.warn("Unexpected exception while clearing MDC data for function invocation.", e);
       }
     }
 
@@ -72,7 +72,9 @@ public class Slf4j1MdcDataInvocationWrapper implements InvocationWrapper {
       try {
         mdcPutMethod.invoke(null, "function-invocation-id", cloudEvent.getId());
       } catch (IllegalAccessException | InvocationTargetException e) {
-        e.printStackTrace();
+        LOGGER.warn(
+            "Unexpected exception while setting 'function-invocation-id' MDC data for function invocation.",
+            e);
       }
     }
 


### PR DESCRIPTION
`Slf4j1MdcDataInvocationWrapper` might have printed exception stack traces instead of properly logging. All four exceptions are very unlikely to happen and we cannot do anything about them. Logging their occurrence at `WARN` is the best we can do.

Closes [W-9272915](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000LrSqYAK/view)