### PR TITLE
Polish SDK implementation tests

### DIFF
--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/ContextImplTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/ContextImplTest.java
@@ -66,7 +66,7 @@ public class ContextImplTest {
   public void testContextValues() {
     Context context = new ContextImpl(cloudEvent, contextExtension, functionContextExtension);
 
-    assertThat(context.getId(), equalTo(cloudEvent.getId()));
+    assertThat(context.getId(), is(equalTo(cloudEvent.getId())));
     assertThat(context.getOrg(), is(optionalWithValue()));
   }
 
@@ -74,10 +74,12 @@ public class ContextImplTest {
   public void testOrgValues() {
     Org org = new OrgImpl(contextExtension, functionContextExtension);
 
-    assertThat(org.getId(), equalTo(contextExtension.getUserContext().getOrgId()));
-    assertThat(org.getBaseUrl(), equalTo(contextExtension.getUserContext().getSalesforceBaseUrl()));
-    assertThat(org.getDomainUrl(), equalTo(contextExtension.getUserContext().getOrgDomainUrl()));
-    assertThat(org.getApiVersion(), equalTo(contextExtension.getApiVersion()));
+    assertThat(org.getId(), is(equalTo(contextExtension.getUserContext().getOrgId())));
+    assertThat(
+        org.getBaseUrl(), is(equalTo(contextExtension.getUserContext().getSalesforceBaseUrl())));
+    assertThat(
+        org.getDomainUrl(), is(equalTo(contextExtension.getUserContext().getOrgDomainUrl())));
+    assertThat(org.getApiVersion(), is(equalTo(contextExtension.getApiVersion())));
     assertThat(org.getUser(), is(notNullValue()));
     assertThat(org.getDataApi(), is(notNullValue()));
   }
@@ -86,8 +88,8 @@ public class ContextImplTest {
   public void testUserValues() {
     User user = new UserImpl(contextExtension);
 
-    assertThat(user.getId(), equalTo(contextExtension.getUserContext().getUserId()));
-    assertThat(user.getUsername(), equalTo(contextExtension.getUserContext().getUsername()));
+    assertThat(user.getId(), is(equalTo(contextExtension.getUserContext().getUserId())));
+    assertThat(user.getUsername(), is(equalTo(contextExtension.getUserContext().getUsername())));
     assertThat(user.getOnBehalfOfUserId(), is(emptyOptional()));
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImplTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImplTest.java
@@ -42,17 +42,19 @@ public class DataApiImplTest {
     List<Record> records = result.getRecords();
     assertThat(
         records.get(0).getStringField("Name"),
-        optionalWithValue(equalTo("An awesome test account")));
+        is(optionalWithValue(equalTo("An awesome test account"))));
 
-    assertThat(records.get(1).getStringField("Name"), optionalWithValue(equalTo("Global Media")));
+    assertThat(
+        records.get(1).getStringField("Name"), is(optionalWithValue(equalTo("Global Media"))));
 
-    assertThat(records.get(2).getStringField("Name"), optionalWithValue(equalTo("Acme")));
+    assertThat(records.get(2).getStringField("Name"), is(optionalWithValue(equalTo("Acme"))));
 
-    assertThat(records.get(3).getStringField("Name"), optionalWithValue(equalTo("salesforce.com")));
+    assertThat(
+        records.get(3).getStringField("Name"), is(optionalWithValue(equalTo("salesforce.com"))));
 
     assertThat(
         records.get(4).getStringField("Name"),
-        optionalWithValue(equalTo("Sample Account for Entitlements")));
+        is(optionalWithValue(equalTo("Sample Account for Entitlements"))));
   }
 
   @Test
@@ -88,8 +90,8 @@ public class DataApiImplTest {
               "One or more API errors occurred:\n\nCode: MALFORMED_QUERY\nMessage: unexpected token: SELEKT\nFields: \n"));
 
       assertThat(e.getDataApiErrors(), hasSize(1));
-      assertThat(e.getDataApiErrors().get(0).getErrorCode(), equalTo("MALFORMED_QUERY"));
-      assertThat(e.getDataApiErrors().get(0).getMessage(), equalTo("unexpected token: SELEKT"));
+      assertThat(e.getDataApiErrors().get(0).getErrorCode(), is(equalTo("MALFORMED_QUERY")));
+      assertThat(e.getDataApiErrors().get(0).getMessage(), is(equalTo("unexpected token: SELEKT")));
       assertThat(e.getDataApiErrors().get(0).getFields(), is(empty()));
       return;
     }
@@ -107,7 +109,7 @@ public class DataApiImplTest {
                 .withField("Rating__c", "Excellent")
                 .build());
 
-    assertThat(result.getId(), equalTo("a00B000000FSkcvIAD"));
+    assertThat(result.getId(), is(equalTo("a00B000000FSkcvIAD")));
   }
 
   @Test
@@ -120,7 +122,7 @@ public class DataApiImplTest {
                 .withField("ReleaseDate__c", "1980-05-21")
                 .build());
 
-    assertThat(result.getId(), equalTo("a00B000000FSjVUIA1"));
+    assertThat(result.getId(), is(equalTo("a00B000000FSjVUIA1")));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -133,7 +135,7 @@ public class DataApiImplTest {
   public void testDelete() throws DataApiException {
     RecordModificationResult result = dataApi.delete("Account", "001B000001Lp1FxIAJ");
 
-    assertThat(result.getId(), equalTo("001B000001Lp1FxIAJ"));
+    assertThat(result.getId(), is(equalTo("001B000001Lp1FxIAJ")));
   }
 
   @Test

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/InvocationEventTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/InvocationEventTest.java
@@ -10,6 +10,7 @@ import static com.spotify.hamcrest.optional.OptionalMatchers.emptyOptional;
 import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.v1.CloudEventBuilder;
@@ -30,13 +31,13 @@ public class InvocationEventTest {
 
     InvocationEventImpl<String> event = new InvocationEventImpl<>(cloudEvent, "Payload");
 
-    assertThat(event.getData(), equalTo("Payload"));
-    assertThat(event.getId(), equalTo(cloudEvent.getId()));
-    assertThat(event.getSource(), equalTo(cloudEvent.getSource()));
-    assertThat(event.getType(), equalTo(cloudEvent.getType()));
-    assertThat(event.getDataContentType(), emptyOptional());
-    assertThat(event.getTime(), emptyOptional());
-    assertThat(event.getDataSchema(), emptyOptional());
+    assertThat(event.getData(), is(equalTo("Payload")));
+    assertThat(event.getId(), is(equalTo(cloudEvent.getId())));
+    assertThat(event.getSource(), is(equalTo(cloudEvent.getSource())));
+    assertThat(event.getType(), is(equalTo(cloudEvent.getType())));
+    assertThat(event.getDataContentType(), is(emptyOptional()));
+    assertThat(event.getTime(), is(emptyOptional()));
+    assertThat(event.getDataSchema(), is(emptyOptional()));
   }
 
   @Test
@@ -53,13 +54,14 @@ public class InvocationEventTest {
 
     InvocationEventImpl<String> event = new InvocationEventImpl<>(cloudEvent, "Payload");
 
-    assertThat(event.getData(), equalTo("Payload"));
-    assertThat(event.getId(), equalTo(cloudEvent.getId()));
-    assertThat(event.getSource(), equalTo(cloudEvent.getSource()));
-    assertThat(event.getType(), equalTo(cloudEvent.getType()));
+    assertThat(event.getData(), is(equalTo("Payload")));
+    assertThat(event.getId(), is(equalTo(cloudEvent.getId())));
+    assertThat(event.getSource(), is(equalTo(cloudEvent.getSource())));
+    assertThat(event.getType(), is(equalTo(cloudEvent.getType())));
     assertThat(
-        event.getDataContentType(), optionalWithValue(equalTo(cloudEvent.getDataContentType())));
-    assertThat(event.getTime(), optionalWithValue(equalTo(cloudEvent.getTime())));
-    assertThat(event.getDataSchema(), optionalWithValue(equalTo(cloudEvent.getDataSchema())));
+        event.getDataContentType(),
+        is(optionalWithValue(equalTo(cloudEvent.getDataContentType()))));
+    assertThat(event.getTime(), is(optionalWithValue(equalTo(cloudEvent.getTime()))));
+    assertThat(event.getDataSchema(), is(optionalWithValue(equalTo(cloudEvent.getDataSchema()))));
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/ReferenceIdImplTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/ReferenceIdImplTest.java
@@ -8,6 +8,7 @@ package com.salesforce.functions.jvm.runtime.sdk;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
@@ -17,7 +18,7 @@ public class ReferenceIdImplTest {
   @Test
   public void testToApiString() {
     ReferenceIdImpl referenceId = new ReferenceIdImpl("foo");
-    assertThat(referenceId.toApiString(), equalTo("@{foo.id}"));
+    assertThat(referenceId.toApiString(), is(equalTo("@{foo.id}")));
   }
 
   @Test

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
@@ -8,6 +8,7 @@ package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import com.google.gson.JsonPrimitive;
 import java.util.HashMap;
@@ -25,8 +26,8 @@ public class RecordTest {
     values.put("bar", new JsonPrimitive("baz"));
 
     Record record = new Record(attributes, values);
-    assertThat("attributes are unmodified", record.getAttributes(), equalTo(attributes));
-    assertThat("values are unmodified", record.getValues(), equalTo(values));
+    assertThat(record.getAttributes(), is(equalTo(attributes)));
+    assertThat(record.getValues(), is(equalTo(values)));
   }
 
   @Test

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
@@ -69,7 +69,6 @@ public class RestApiCompositeTest {
       restApi.execute(request);
     } catch (RestApiErrorsException e) {
       assertThat(
-          "the error from the inner create request is in the error from the composite request",
           e.getApiErrors(),
           contains(
               equalTo(

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.gson.JsonElement;
@@ -39,7 +40,7 @@ public class RestApiCreateTest {
 
     CreateRecordRestApiRequest request = new CreateRecordRestApiRequest("Movie__c", values);
     ModifyRecordResult result = restApi.execute(request);
-    assertThat("id equals expected value", result.getId(), equalTo("a00B000000FSkcvIAD"));
+    assertThat(result.getId(), is(equalTo("a00B000000FSkcvIAD")));
   }
 
   @Test
@@ -56,16 +57,12 @@ public class RestApiCreateTest {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(
-          "The error has the correct message",
           error.getMessage(),
-          equalTo("Rating: bad value for restricted picklist field: Terrible"));
+          is(equalTo("Rating: bad value for restricted picklist field: Terrible")));
 
-      assertThat(
-          "The error has the correct code",
-          error.getErrorCode(),
-          equalTo("INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST"));
+      assertThat(error.getErrorCode(), is(equalTo("INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST")));
 
-      assertThat("The error has the correct fields", error.getFields(), contains("Rating__c"));
+      assertThat(error.getFields(), contains("Rating__c"));
 
       return;
     }
@@ -85,14 +82,11 @@ public class RestApiCreateTest {
     } catch (RestApiErrorsException e) {
       RestApiError error = e.getApiErrors().get(0);
 
-      assertThat(
-          "The error has the correct message",
-          error.getMessage(),
-          equalTo("The requested resource does not exist"));
+      assertThat(error.getMessage(), equalTo("The requested resource does not exist"));
 
-      assertThat("The error has the correct code", error.getErrorCode(), equalTo("NOT_FOUND"));
+      assertThat(error.getErrorCode(), is(equalTo("NOT_FOUND")));
 
-      assertThat("The error has the correct fields", error.getFields(), empty());
+      assertThat(error.getFields(), is(empty()));
 
       return;
     }
@@ -113,13 +107,12 @@ public class RestApiCreateTest {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(
-          "The error has the correct message",
           error.getMessage(),
           equalTo("No such column 'FavoritePet__c' on sobject of type Account"));
 
-      assertThat("The error has the correct code", error.getErrorCode(), equalTo("INVALID_FIELD"));
+      assertThat(error.getErrorCode(), is(equalTo("INVALID_FIELD")));
 
-      assertThat("The error has the correct fields", error.getFields(), empty());
+      assertThat(error.getFields(), is(empty()));
 
       return;
     }
@@ -139,17 +132,11 @@ public class RestApiCreateTest {
     } catch (RestApiErrorsException e) {
       RestApiError error = e.getApiErrors().get(0);
 
-      assertThat(
-          "The error has the correct message",
-          error.getMessage(),
-          equalTo("Required fields are missing: [Website__c]"));
+      assertThat(error.getMessage(), equalTo("Required fields are missing: [Website__c]"));
 
-      assertThat(
-          "The error has the correct code",
-          error.getErrorCode(),
-          equalTo("REQUIRED_FIELD_MISSING"));
+      assertThat(error.getErrorCode(), equalTo("REQUIRED_FIELD_MISSING"));
 
-      assertThat("The error has the correct fields", error.getFields(), contains("Website__c"));
+      assertThat(error.getFields(), contains("Website__c"));
 
       return;
     }

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
@@ -7,6 +7,7 @@
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
 import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.map;
+import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,14 +40,13 @@ public class RestApiQueryTest {
         new QueryRecordRestApiRequest("SELECT RANDOM_1__c, RANDOM_2__c FROM Random__c");
     QueryRecordResult result = restApi.execute(queryRequest);
 
-    assertThat("the result is not done", result.isDone(), is(false));
-    assertThat("the total size is 10000", result.getTotalSize(), is(10000L));
+    assertThat(result.isDone(), is(false));
+    assertThat(result.getTotalSize(), is(10000L));
     assertThat(result.getRecords(), hasSize(2000));
 
     assertThat(
-        "the next records path is present",
         result.getNextRecordsPath(),
-        equalTo(Optional.of("/services/data/v51.0/query/01gB000003OCxSPIA1-2000")));
+        is(optionalWithValue(equalTo("/services/data/v51.0/query/01gB000003OCxSPIA1-2000"))));
   }
 
   @Test
@@ -59,7 +59,7 @@ public class RestApiQueryTest {
         new QueryNextRecordsRestApiRequest(result.getNextRecordsPath().get());
     QueryRecordResult result2 = restApi.execute(queryMoreRequest);
 
-    assertThat("2000 records are present", result2.getRecords().size(), equalTo(2000));
+    assertThat(result2.getRecords(), hasSize(2000));
   }
 
   @Test
@@ -70,18 +70,17 @@ public class RestApiQueryTest {
     try {
       restApi.execute(queryRequest);
     } catch (RestApiErrorsException e) {
-      assertThat("Exactly one error is returned", e.getApiErrors().size(), is(1));
+      assertThat(e.getApiErrors(), hasSize(1));
 
       RestApiError apiError = e.getApiErrors().get(0);
 
       assertThat(
-          "The error has the correct message",
           apiError.getMessage(),
-          equalTo(
-              "\nSELECT Bacon__c FROM Account LIMIT 2\n       ^\nERROR at Row:1:Column:8\nNo such column 'Bacon__c' on entity 'Account'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names."));
+          is(
+              equalTo(
+                  "\nSELECT Bacon__c FROM Account LIMIT 2\n       ^\nERROR at Row:1:Column:8\nNo such column 'Bacon__c' on entity 'Account'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names.")));
 
-      assertThat(
-          "The error has the correct code", apiError.getErrorCode(), equalTo("INVALID_FIELD"));
+      assertThat(apiError.getErrorCode(), is(equalTo("INVALID_FIELD")));
       return;
     }
 
@@ -96,17 +95,13 @@ public class RestApiQueryTest {
     try {
       restApi.execute(queryRequest);
     } catch (RestApiErrorsException e) {
-      assertThat("Exactly one error is returned", e.getApiErrors().size(), is(1));
+      assertThat(e.getApiErrors(), hasSize(1));
 
       RestApiError apiError = e.getApiErrors().get(0);
 
-      assertThat(
-          "The error has the correct message",
-          apiError.getMessage(),
-          equalTo("unexpected token: SELEKT"));
+      assertThat(apiError.getMessage(), is(equalTo("unexpected token: SELEKT")));
 
-      assertThat(
-          "The error has the correct code", apiError.getErrorCode(), equalTo("MALFORMED_QUERY"));
+      assertThat(apiError.getErrorCode(), is(equalTo("MALFORMED_QUERY")));
       return;
     }
 
@@ -119,9 +114,9 @@ public class RestApiQueryTest {
         new QueryRecordRestApiRequest("SELECT Name FROM Account");
     QueryRecordResult result = restApi.execute(queryRequest);
 
-    assertThat("total size is correct", result.getTotalSize(), is(5L));
-    assertThat("is done is true", result.isDone(), is(true));
-    assertThat("next record path is empty", result.getNextRecordsPath(), equalTo(Optional.empty()));
+    assertThat(result.getTotalSize(), is(5L));
+    assertThat(result.isDone(), is(true));
+    assertThat(result.getNextRecordsPath(), equalTo(Optional.empty()));
 
     List<Record> expectedRecords = new ArrayList<>();
     expectedRecords.add(
@@ -159,6 +154,6 @@ public class RestApiQueryTest {
                 new Tuple("url", "/services/data/v51.0/sobjects/Account/001B000001LnobCIAR")),
             map(new Tuple("Name", "Sample Account for Entitlements"))));
 
-    assertThat("records match", result.getRecords(), equalTo(expectedRecords));
+    assertThat(result.getRecords(), is(equalTo(expectedRecords)));
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
@@ -10,6 +10,7 @@ import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.map
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.Tuple;
@@ -40,6 +41,8 @@ public class RestApiQueryTest {
 
     assertThat("the result is not done", result.isDone(), is(false));
     assertThat("the total size is 10000", result.getTotalSize(), is(10000L));
+    assertThat(result.getRecords(), hasSize(2000));
+
     assertThat(
         "the next records path is present",
         result.getNextRecordsPath(),

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
@@ -9,6 +9,7 @@ package com.salesforce.functions.jvm.runtime.sdk.restapi;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.IOException;
@@ -34,10 +35,7 @@ public class RestApiTest {
     try {
       restApi.execute(queryRequest);
     } catch (RestApiException e) {
-      assertThat(
-          "the exception message is matching the error",
-          e.getMessage(),
-          startsWith("Could not parse API response as JSON!"));
+      assertThat(e.getMessage(), startsWith("Could not parse API response as JSON!"));
 
       return;
     }
@@ -47,16 +45,15 @@ public class RestApiTest {
 
   @Test
   public void testApiVersionGetter() {
-    assertThat(
-        "getApiVersion returns the correct API version", restApi.getApiVersion(), equalTo("51.0"));
+    assertThat(restApi.getApiVersion(), is(equalTo("51.0")));
   }
 
   @Test
   public void testAccessTokenGetter() {
     assertThat(
-        "getAccessToken returns the correct access token",
         restApi.getAccessToken(),
-        equalTo(
-            "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"));
+        is(
+            equalTo(
+                "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS")));
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.gson.JsonElement;
@@ -38,8 +39,9 @@ public class RestApiUpdateTest {
 
     UpdateRecordRestApiRequest request =
         new UpdateRecordRestApiRequest("a00B000000FSjVUIA1", "Movie__c", values);
+
     ModifyRecordResult result = restApi.execute(request);
-    assertThat("id equals expected value", result.getId(), equalTo("a00B000000FSjVUIA1"));
+    assertThat(result.getId(), is(equalTo("a00B000000FSjVUIA1")));
   }
 
   @Test
@@ -56,13 +58,10 @@ public class RestApiUpdateTest {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(
-          "The error has the correct message",
-          error.getMessage(),
-          equalTo("Record ID: id value of incorrect type: a00B000000FSjVUIB1"));
+          error.getMessage(), equalTo("Record ID: id value of incorrect type: a00B000000FSjVUIB1"));
 
-      assertThat("The error has the correct code", error.getErrorCode(), equalTo("MALFORMED_ID"));
-
-      assertThat("The error has the correct fields", error.getFields(), contains("Id"));
+      assertThat(error.getErrorCode(), is(equalTo("MALFORMED_ID")));
+      assertThat(error.getFields(), contains("Id"));
 
       return;
     }
@@ -84,13 +83,10 @@ public class RestApiUpdateTest {
       RestApiError error = e.getApiErrors().get(0);
 
       assertThat(
-          "The error has the correct message",
-          error.getMessage(),
-          equalTo("No such column 'Color__c' on sobject of type Movie__c"));
+          error.getMessage(), equalTo("No such column 'Color__c' on sobject of type Movie__c"));
 
-      assertThat("The error has the correct code", error.getErrorCode(), equalTo("INVALID_FIELD"));
-
-      assertThat("The error has the correct fields", error.getFields(), empty());
+      assertThat(error.getErrorCode(), is(equalTo("INVALID_FIELD")));
+      assertThat(error.getFields(), is(empty()));
 
       return;
     }


### PR DESCRIPTION
Adds a check for the size of the returned `Record` collection of `queryWithNextRecordsUrl`. Otherwise only cosmetic changes and no changes to the tests themselves.