### PR TITLE
Add aggregated coverage reports + codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@1.0.2
+
 executors:
   openjdk-8:
     docker:
@@ -17,7 +20,7 @@ jobs:
       name: << parameters.executor >>
     steps:
       - checkout
-      - run: ./mvnw package
+      - run: ./mvnw clean package
       - run:
           name: Save test results
           command: |
@@ -28,6 +31,8 @@ jobs:
           path: ~/test-results
       - store_artifacts:
           path: ~/test-results/junit
+      - codecov/upload:
+          file: "coverage/target/site/jacoco-aggregate/jacoco.xml"
 
 workflows:
   ci:

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>sf-fx-runtime-java</artifactId>
+        <groupId>com.salesforce.functions</groupId>
+        <version>0.2.5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>coverage</artifactId>
+    <name>coverage</name>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.salesforce.functions</groupId>
+            <artifactId>sf-fx-runtime-java-cloudevent</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.salesforce.functions</groupId>
+            <artifactId>sf-fx-runtime-java-logger</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.salesforce.functions</groupId>
+            <artifactId>sf-fx-runtime-java-runtime</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.salesforce.functions</groupId>
+            <artifactId>sf-fx-runtime-java-sdk-impl-v1</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <module>sf-fx-runtime-java-sdk-impl-v1</module>
         <module>sf-fx-runtime-java-logger</module>
         <module>sf-fx-runtime-java-runtime</module>
+        <module>coverage</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Adds aggregated coverage reports with the `coverage` module. Also sets up codecov for monitoring code coverage in future pull-requests.

Closes [GUS-W-9302314](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000MTi1YAG/view)