### PR TITLE
Rename stacktrace to stack in serialized ExtraInfo

### DIFF
--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/ExtraInfo.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/ExtraInfo.java
@@ -40,7 +40,7 @@ public class ExtraInfo {
   private final boolean isFunctionError;
 
   @Expose
-  @SerializedName("stacktrace")
+  @SerializedName("stack")
   @JsonAdapter(StackTraceElementListJsonSerializer.class)
   private final List<StackTraceElement> stacktrace;
 

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/invocation/undertow/ExtraInfoTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/invocation/undertow/ExtraInfoTest.java
@@ -151,6 +151,6 @@ public class ExtraInfoTest {
         new Gson().toJson(extraInfo),
         is(
             equalTo(
-                "{\"requestId\":\"requestId\",\"source\":\"source\",\"execTimeMs\":60000,\"statusCode\":200,\"isFunctionError\":true,\"stacktrace\":[\"com.example.Test.testMethod(Test.java:1337)\"]}")));
+                "{\"requestId\":\"requestId\",\"source\":\"source\",\"execTimeMs\":60000,\"statusCode\":200,\"isFunctionError\":true,\"stack\":[\"com.example.Test.testMethod(Test.java:1337)\"]}")));
   }
 }


### PR DESCRIPTION
Bugfix: Rename`stacktrace` to`stack` in serialized ExtraInfo to make it spec compliant.

Closes [W-9501666](https://gus.lightning.force.com/lightning/_classic/%2Fa07AH000000PHbVYAW)