### PR TITLE
Fix Salesforce API version to 51.0

### DIFF
--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/OrgImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/OrgImpl.java
@@ -48,7 +48,10 @@ public class OrgImpl implements Org {
   @Override
   @Nonnull
   public String getApiVersion() {
-    return salesforceContext.getApiVersion();
+    // An API version is also available in the context via #getApiVersion(). That value differs
+    // between orgs and can change seemingly randomly. To avoid surprises at runtime, we
+    // intentionally don't use that value and instead fix the version.
+    return "51.0";
   }
 
   @Override


### PR DESCRIPTION
Fix Salesforce API version to `51.0`. Tests already used `51.0`, so no test changes necessary.

Closes [GUS-W-9529481](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000PoNLYA0/view)