### PR TITLE
Support List<string> input and output

### DIFF
--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
@@ -300,6 +300,8 @@ public class SalesforceFunctionsProjectFunctionsScanner
         FunctionResultMarshaller marshaller = null;
         if (returnTypeString.equals("java.lang.String")) {
           marshaller = new StringFunctionResultMarshaller();
+        } else if (returnTypeString.equals("java.util.List<java.lang.String>")) {
+          marshaller = new ListFunctionResultMarshaller();
         } else {
           try {
             Class<?> clazz = projectClassLoader.loadClass(returnTypeString);

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
@@ -269,6 +269,8 @@ public class SalesforceFunctionsProjectFunctionsScanner
         PayloadUnmarshaller unmarshaller = null;
         if (payloadTypeArgument.equals("byte[]")) {
           unmarshaller = new ByteArrayPayloadUnmarshaller();
+        } else if (payloadTypeArgument.equals("java.util.List<java.lang.String>")) {
+          unmarshaller = new ListPayloadUnmarshaller();
         } else {
           try {
             Class<?> clazz = projectClassLoader.loadClass(payloadTypeArgument);

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListFunctionResultMarshaller.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListFunctionResultMarshaller.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sfjavafunction.marshalling;
+
+import com.google.common.net.MediaType;
+import com.google.gson.Gson;
+import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.FunctionResultMarshallingException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class ListFunctionResultMarshaller implements FunctionResultMarshaller {
+  @Override
+  public MediaType getMediaType() {
+    return MediaType.JSON_UTF_8;
+  }
+
+  @Override
+  public Class<?> getSourceClass() {
+    return List.class;
+  }
+
+  @Override
+  public byte[] marshallBytes(Object object) throws FunctionResultMarshallingException {
+    if (!(object instanceof List)) {
+      throw new FunctionResultMarshallingException(
+          String.format(
+              "Expected java.lang.List for marshalling, got %s!", object.getClass().getName()));
+    }
+
+    return new Gson().toJson((List<String>) object, List.class).getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListPayloadUnmarshaller.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListPayloadUnmarshaller.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sfjavafunction.marshalling;
+
+import com.google.common.net.MediaType;
+import com.google.gson.Gson;
+import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.PayloadUnmarshallingException;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class ListPayloadUnmarshaller implements PayloadUnmarshaller {
+  @Override
+  public MediaType getHandledMediaType() {
+    return MediaType.JSON_UTF_8;
+  }
+
+  @Override
+  public Class<?> getTargetClass() {
+    return List.class;
+  }
+
+  @Override
+  public Object unmarshall(CloudEvent cloudEvent) throws PayloadUnmarshallingException {
+    CloudEventData data = cloudEvent.getData();
+    if (data == null) {
+      throw new PayloadUnmarshallingException("No data given");
+    }
+
+    return new Gson().fromJson(new String(data.toBytes(), StandardCharsets.UTF_8), List.class);
+  }
+}

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListPayloadUnmarshaller.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListPayloadUnmarshaller.java
@@ -31,7 +31,6 @@ public class ListPayloadUnmarshaller implements PayloadUnmarshaller {
     if (data == null) {
       throw new PayloadUnmarshallingException("No data given");
     }
-
     return new Gson().fromJson(new String(data.toBytes(), StandardCharsets.UTF_8), List.class);
   }
 }

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListFunctionResultMarshallerTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListFunctionResultMarshallerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sfjavafunction.marshalling;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import com.google.common.net.MediaType;
+import com.salesforce.functions.jvm.runtime.sfjavafunction.SalesforceFunctionResult;
+import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.FunctionResultMarshallingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class ListFunctionResultMarshallerTest {
+
+  @Test
+  public void testSuccess() {
+    FunctionResultMarshaller marshaller = new ListFunctionResultMarshaller();
+    List<String> data = new ArrayList<>();
+    data.add("Hello 👋🏻!");
+    SalesforceFunctionResult result = marshaller.marshall(data);
+
+    assertThat(result.getMediaType(), is(MediaType.JSON_UTF_8));
+
+    assertThat(result.getData(), is(equalTo("[\"Hello 👋🏻!\"]".getBytes(StandardCharsets.UTF_8))));
+  }
+
+  @Test(expected = FunctionResultMarshallingException.class)
+  public void testFailure() {
+    FunctionResultMarshaller marshaller = new ListFunctionResultMarshaller();
+    marshaller.marshall(23);
+  }
+}

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListPayloadUnmarshallerTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/marshalling/ListPayloadUnmarshallerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sfjavafunction.marshalling;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.PayloadUnmarshallingException;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.v1.CloudEventBuilder;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.Test;
+
+public class ListPayloadUnmarshallerTest {
+
+  @Test
+  public void testString() {
+    PayloadUnmarshaller unmarshaller = new ListPayloadUnmarshaller();
+
+    byte[] data = "['foo', 'bar']".getBytes(StandardCharsets.UTF_8);
+
+    List<String> result = (List<String>) unmarshaller.unmarshall(createCloudEventWithData(data));
+
+    assertThat(result, is(instanceOf(List.class)));
+    assertThat(result, hasItems("foo", "bar"));
+  }
+
+  @Test(expected = PayloadUnmarshallingException.class)
+  public void testWithoutData() {
+    PayloadUnmarshaller unmarshaller = new ListPayloadUnmarshaller();
+
+    CloudEvent cloudEvent =
+        new CloudEventBuilder()
+            .withId("id")
+            .withSource(URI.create("urn:foo"))
+            .withType("type")
+            .build();
+
+    Object result = unmarshaller.unmarshall(cloudEvent);
+  }
+
+  private CloudEvent createCloudEventWithData(byte[] data) {
+    return new CloudEventBuilder()
+        .withId("id")
+        .withSource(URI.create("urn:foo"))
+        .withType("type")
+        .withData(data)
+        .build();
+  }
+}


### PR DESCRIPTION
Functions can now accept a list of strings `List<String>` from json:

```
$ ~/Documents/projects/work/sf-fx-runtime-nodejs/invoke.sh localhost:8080"['hello', 'world']"
# no error
```

Functions can now return a list of strings `List<String>` to json. Example function:

```
public class ExampleFunction implements SalesforceFunction<FunctionInput, List<String>> {
 private static final Logger LOGGER = LoggerFactory.getLogger(ExampleFunction.class);

 @override
 public List<String> apply(InvocationEvent<FunctionInput> event, Context context)
   throws Exception {

  List<Account> accounts = new ArrayList<>();
  List<String> foo = new ArrayList<>();
  foo.add("Lol");

  return foo;
 }
```

Output:

```
$ ~/Documents/projects/work/sf-fx-runtime-nodejs/invoke.sh localhost:8080 "{'hello': 'world'}"
# ...
* Connection #0 to host localhost left intact
["Lol"]* Closing connection 0
```