### PR TITLE
Move coverage module to aggregate-coverage Maven profile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,13 @@ jobs:
           path: ~/test-results
       - store_artifacts:
           path: ~/test-results/junit
+
+  coverage-report:
+    executor:
+      name: "openjdk-11"
+    steps:
+      - checkout
+      - run: ./mvnw clean package -Paggregate-coverage
       - codecov/upload:
           file: "coverage/target/site/jacoco-aggregate/jacoco.xml"
 
@@ -52,6 +59,7 @@ jobs:
 workflows:
   ci:
     jobs:
+      - coverage-report
       - maven:
           matrix:
             parameters:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Usage: sf-fx-runtime-java bundle <projectPath> <bundlePath>
 
 ### Generating Code Coverage Reports
 ```
-$ ./mvnw clean package
+$ ./mvnw clean package -Paggregate-coverage
 ```
 
 After building, an aggregated report across all project modules can be found at [coverage/target/site/jacoco-aggregate/index.html](coverage/target/site/jacoco-aggregate/index.html)

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
         <module>sf-fx-runtime-java-sdk-impl-v1</module>
         <module>sf-fx-runtime-java-logger</module>
         <module>sf-fx-runtime-java-runtime</module>
-        <module>coverage</module>
     </modules>
 
     <properties>
@@ -343,6 +342,16 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+
+        <profile>
+            <id>aggregate-coverage</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>coverage</module>
+            </modules>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This avoids the coverage module to be part of the deployment process. The README has been updated to reflect this change.

Closes [GUS-W-9590808](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000QyxgYAC/view)