### PR TITLE
Windows Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@1.0.2
+  windows: circleci/windows@2.4.1
 
 executors:
   openjdk-8:
@@ -57,10 +58,20 @@ jobs:
       - run: ./integration-test/<< parameters.executor >>/list-pojo/test.sh
       - run: ./integration-test/<< parameters.executor >>/exception/test.sh
 
+  maven-windows:
+    executor:
+      name: "windows/default"
+      shell: cmd.exe
+    steps:
+      - checkout
+      # Skipping JavaDoc due to a bug in the installed JavaDoc version that cases the process to fail.
+      - run: mvnw.cmd clean package -Dmaven.javadoc.skip=true
+
 workflows:
   ci:
     jobs:
       - coverage-report
+      - maven-windows
       - maven:
           matrix:
             parameters:

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/UndertowInvocationInterface.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/UndertowInvocationInterface.java
@@ -217,7 +217,9 @@ public class UndertowInvocationInterface
                 + " ("
                 + e.getCause().getMessage()
                 + ")\n"
-                + Throwables.getStackTraceAsString(e.getCause());
+                // When running on Windows, the stack trace string will contain Windows
+                // line-endings so we have to normalize them here:
+                + Throwables.getStackTraceAsString(e.getCause()).replaceAll("\\r\\n", "\\\n");
 
         makeResponse(
             exchange,

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/util/ProjectClassLoaderBuilder.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/util/ProjectClassLoaderBuilder.java
@@ -50,6 +50,10 @@ public final class ProjectClassLoaderBuilder {
   private static URL pathToURLClassLoaderURL(Path path) {
     String absolutePathAsString = path.toAbsolutePath().toString();
 
+    if (!absolutePathAsString.startsWith("/")) {
+      absolutePathAsString = "/" + absolutePathAsString;
+    }
+
     // URLClassLoader strictly requires that directories end with a slash. Without it, the contents
     // of the directory will not be visible to the classloader.
     if (Files.isDirectory(path)) {

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/json/UtilTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/json/UtilTest.java
@@ -28,7 +28,7 @@ public class UtilTest {
 
     assertThat(
         annotationList,
-        contains(
+        containsInAnyOrder(
             equalTo(createAnnotation(Foo.class, "publicField")),
             equalTo(createAnnotation(Bar.class, "privateField")),
             equalTo(createAnnotation(Foo.class, "publicMethod")),

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/ProjectTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/ProjectTest.java
@@ -60,8 +60,10 @@ public class ProjectTest {
     assertThat(
         classUrlsFromClassLoader,
         contains(
-            hasToString(containsString(log4jBindingJarPath.toString())),
-            hasToString(containsString(logbackClassicJarPath.toString())),
-            hasToString(containsString(julBindingJarPath.toString()))));
+            // On Windows, the backslashes, and only the backslashes are URI escaped. Because of
+            // this, we dont use URIEncoder here and rely on direct string replacements.
+            hasToString(containsString(log4jBindingJarPath.toString().replaceAll("\\\\", "%5C"))),
+            hasToString(containsString(logbackClassicJarPath.toString().replaceAll("\\\\", "%5C"))),
+            hasToString(containsString(julBindingJarPath.toString().replaceAll("\\\\", "%5C")))));
   }
 }

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/test/Util.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/test/Util.java
@@ -27,6 +27,7 @@ public class Util {
     ReadableByteChannel readableByteChannel = Channels.newChannel(new URL(url).openStream());
     FileOutputStream fileOutputStream = new FileOutputStream(path.toFile());
     fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+    fileOutputStream.close();
   }
 
   public static Path downloadFileToTemporary(String url) throws IOException {


### PR DESCRIPTION
Previously, `sf-fx-runtime-java` only targeted *NIX operating systems. This PR adds CI configuration to run the tests on a Windows machine and fixes several issues uncovered by the tests.

Fixes GUS-W-10235242