### PR TITLE
Remove references to log4j JAR files

### DIFF
--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/ProjectTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/ProjectTest.java
@@ -22,9 +22,9 @@ public class ProjectTest {
 
   @Test
   public void testJarOrdering() throws IOException {
-    Path log4jBindingJarPath =
+    Path nopBindingPath =
         downloadFileToTemporary(
-            "https://repo1.maven.org/maven2/org/slf4j/slf4j-log4j12/1.7.30/slf4j-log4j12-1.7.30.jar");
+            "https://repo1.maven.org/maven2/org/slf4j/slf4j-nop/1.7.32/slf4j-nop-1.7.32.jar");
 
     Path logbackClassicJarPath =
         downloadFileToTemporary(
@@ -51,7 +51,7 @@ public class ProjectTest {
           }
         };
 
-    ClassLoader classLoader = project.createClassLoader(log4jBindingJarPath);
+    ClassLoader classLoader = project.createClassLoader(nopBindingPath);
     List<URL> classUrlsFromClassLoader =
         Collections.list(classLoader.getResources("org/slf4j/impl/StaticLoggerBinder.class"));
 
@@ -62,7 +62,7 @@ public class ProjectTest {
         contains(
             // On Windows, the backslashes, and only the backslashes are URI escaped. Because of
             // this, we dont use URIEncoder here and rely on direct string replacements.
-            hasToString(containsString(log4jBindingJarPath.toString().replaceAll("\\\\", "%5C"))),
+            hasToString(containsString(nopBindingPath.toString().replaceAll("\\\\", "%5C"))),
             hasToString(containsString(logbackClassicJarPath.toString().replaceAll("\\\\", "%5C"))),
             hasToString(containsString(julBindingJarPath.toString().replaceAll("\\\\", "%5C")))));
   }

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/builder/bundle/FunctionBundleProjectBuilderTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/builder/bundle/FunctionBundleProjectBuilderTest.java
@@ -34,8 +34,8 @@ public class FunctionBundleProjectBuilderTest {
 
     Files.move(
         downloadFileToTemporary(
-            "https://repo1.maven.org/maven2/org/slf4j/slf4j-log4j12/1.7.30/slf4j-log4j12-1.7.30.jar"),
-        classpathPath.resolve("slf4j-log4j12-1.7.30.jar"));
+            "https://repo1.maven.org/maven2/org/tinylog/tinylog-api/2.4.1/tinylog-api-2.4.1.jar"),
+        classpathPath.resolve("tinylog-1.3.6.jar"));
 
     Files.move(
         downloadFileToTemporary(
@@ -55,7 +55,7 @@ public class FunctionBundleProjectBuilderTest {
     ClassLoader classLoader = project.createClassLoader();
 
     assertThat(classLoader.loadClass("ch.qos.logback.classic.Level"), is(notNullValue()));
-    assertThat(classLoader.loadClass("org.slf4j.impl.VersionUtil"), is(notNullValue()));
+    assertThat(classLoader.loadClass("org.tinylog.Logger"), is(notNullValue()));
   }
 
   @Test

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/AllowListClassLoaderTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/AllowListClassLoaderTest.java
@@ -24,7 +24,7 @@ public class AllowListClassLoaderTest {
   private final ClassLoader allowListClassLoader;
 
   private final List<String> classesOnlyInParentClassLoader =
-      Collections.singletonList("org.apache.log4j.ConsoleAppender");
+      Collections.singletonList("org.tinylog.Logger");
 
   private final List<String> classesOnlyInExposedClassLoader =
       Arrays.asList(
@@ -41,10 +41,10 @@ public class AllowListClassLoaderTest {
   public AllowListClassLoaderTest() throws Exception {
     exposedClassLoader = getClass().getClassLoader();
 
-    Path log4jJarPath =
+    Path tinyLogJarPath =
         Util.downloadFileToTemporary(
-            "https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.jar");
-    parentClassLoader = ProjectClassLoaderBuilder.build(Collections.singletonList(log4jJarPath));
+            "https://repo1.maven.org/maven2/org/tinylog/tinylog-api/2.4.1/tinylog-api-2.4.1.jar");
+    parentClassLoader = ProjectClassLoaderBuilder.build(Collections.singletonList(tinyLogJarPath));
 
     allowListClassLoader =
         new AllowListClassLoader(


### PR DESCRIPTION
sf-fx-runtime-java never used log4j for it's logging. However, in some tests we manually downloaded log4j JAR files to test classloader isolation between the customer's function and the runtime itself. Log4j code was never executed in tests. We remove these references to avoid false-positive detection of log4j usage via automated tools or manual grepping. Since log4j was never actually used, we replaced that JAR with another one for classloader tests.