### PR TITLE
Salesforce Functions API Version Pinning

### DIFF
--- a/integration-test/openjdk-11/exception/project.toml
+++ b/integration-test/openjdk-11/exception/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-11/list-pojo/project.toml
+++ b/integration-test/openjdk-11/list-pojo/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-11/pojo-gson/project.toml
+++ b/integration-test/openjdk-11/pojo-gson/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-11/pojo-jackson/project.toml
+++ b/integration-test/openjdk-11/pojo-jackson/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-11/pojo/project.toml
+++ b/integration-test/openjdk-11/pojo/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-11/string-reverse/project.toml
+++ b/integration-test/openjdk-11/string-reverse/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-8/exception/project.toml
+++ b/integration-test/openjdk-8/exception/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-8/list-pojo/project.toml
+++ b/integration-test/openjdk-8/list-pojo/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-8/pojo-gson/project.toml
+++ b/integration-test/openjdk-8/pojo-gson/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-8/pojo-jackson/project.toml
+++ b/integration-test/openjdk-8/pojo-jackson/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-8/pojo/project.toml
+++ b/integration-test/openjdk-8/pojo/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/integration-test/openjdk-8/string-reverse/project.toml
+++ b/integration-test/openjdk-8/string-reverse/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/sf-fx-runtime-java-runtime/pom.xml
+++ b/sf-fx-runtime-java-runtime/pom.xml
@@ -20,6 +20,7 @@
     <picocli.version>4.6.2</picocli.version>
     <slf4j.version>1.7.35</slf4j.version>
     <logback.version>1.2.10</logback.version>
+    <tomlj.version>1.0.0</tomlj.version>
   </properties>
 
   <dependencies>
@@ -78,6 +79,11 @@
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.tomlj</groupId>
+      <artifactId>tomlj</artifactId>
+      <version>${tomlj.version}</version>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -95,12 +101,6 @@
       <groupId>io.leangen.geantyref</groupId>
       <artifactId>geantyref</artifactId>
       <version>1.3.13</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.tomlj</groupId>
-      <artifactId>tomlj</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/Constants.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2022, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/Constants.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/Constants.java
@@ -18,6 +18,7 @@ public final class Constants {
   static {
     List<String> versions = new ArrayList<>();
     versions.add("53.0");
+    versions.add("54.0");
 
     SUPPORTED_SALESFORCE_API_VERSIONS = Collections.unmodifiableList(versions);
   }

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/Constants.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/Constants.java
@@ -6,6 +6,19 @@
  */
 package com.salesforce.functions.jvm.runtime;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public final class Constants {
   public static String DEFAULT_SALESFORCE_API_VERSION = "53.0";
+
+  public static final List<String> SUPPORTED_SALESFORCE_API_VERSIONS;
+
+  static {
+    List<String> versions = new ArrayList<>();
+    versions.add("53.0");
+
+    SUPPORTED_SALESFORCE_API_VERSIONS = Collections.unmodifiableList(versions);
+  }
 }

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/Constants.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/Constants.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime;
+
+public final class Constants {
+  public static String DEFAULT_SALESFORCE_API_VERSION = "53.0";
+}

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/bundle/FunctionBundler.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/bundle/FunctionBundler.java
@@ -21,8 +21,11 @@ public class FunctionBundler {
 
   private FunctionBundler() {}
 
-  public static void bundle(Project project, SalesforceFunction function, Path bundlePath)
+  public static void bundle(
+      Path projectPath, Project project, SalesforceFunction function, Path bundlePath)
       throws IOException {
+
+    Files.copy(projectPath.resolve("project.toml"), bundlePath.resolve("project.toml"));
 
     Path bundleClassPath = Paths.get(bundlePath.toString(), "classpath");
     Files.createDirectories(bundleClassPath);

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/AbstractDetectorCommandImpl.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/AbstractDetectorCommandImpl.java
@@ -87,14 +87,13 @@ public abstract class AbstractDetectorCommandImpl implements Callable<Integer> {
     LOGGER.info("Scanning project for functions...");
     long scanStart = System.currentTimeMillis();
     List<SalesforceFunction> functions =
-        new SalesforceFunctionsProjectFunctionsScanner(projectMetadata).scan(project);
+        new SalesforceFunctionsProjectFunctionsScanner(salesforceApiVersion).scan(project);
     long scanDuration = System.currentTimeMillis() - scanStart;
     LOGGER.info("Found {} function(s) after {}ms.", functions.size(), scanDuration);
 
-    return handle(project, projectMetadata, functions);
+    return handle(project, functions);
   }
 
-  protected abstract Integer handle(
-      Project project, ProjectMetadata projectMetadata, List<SalesforceFunction> functions)
+  protected abstract Integer handle(Project project, List<SalesforceFunction> functions)
       throws Exception;
 }

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/AbstractDetectorCommandImpl.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/AbstractDetectorCommandImpl.java
@@ -79,7 +79,7 @@ public abstract class AbstractDetectorCommandImpl implements Callable<Integer> {
       LOGGER.info("Project uses Salesforce API version {}.", salesforceApiVersion);
     } else {
       LOGGER.error(
-          "Project declares to use unsupported Salesforce API version {}. Exiting.",
+          "Project configuration specifies an unsupported Salesforce API version {}. Exiting.",
           salesforceApiVersion);
       return ExitCodes.UNSUPPORTED_SALESFORCE_API_VERSION;
     }

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/AbstractDetectorCommandImpl.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/AbstractDetectorCommandImpl.java
@@ -71,7 +71,7 @@ public abstract class AbstractDetectorCommandImpl implements Callable<Integer> {
       salesforceApiVersion = projectMetadata.getSalesforceApiVersion().get();
     } else {
       LOGGER.warn(
-          "Project Salesforce API version isn't explicitly defined in project.toml. The default version {} will be used.",
+          "Project's Salesforce API version isn't explicitly defined in project.toml. The default version {} will be used.",
           Constants.DEFAULT_SALESFORCE_API_VERSION);
     }
 

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/BundleCommandImpl.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/BundleCommandImpl.java
@@ -11,6 +11,7 @@ import static com.salesforce.functions.jvm.runtime.commands.ExitCodes.*;
 import com.salesforce.functions.jvm.runtime.bundle.FunctionBundler;
 import com.salesforce.functions.jvm.runtime.project.Project;
 import com.salesforce.functions.jvm.runtime.project.ProjectBuilder;
+import com.salesforce.functions.jvm.runtime.project.ProjectMetadata;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.SalesforceFunction;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,7 +31,9 @@ class BundleCommandImpl extends AbstractDetectorCommandImpl {
   }
 
   @Override
-  protected Integer handle(Project project, List<SalesforceFunction> functions) throws Exception {
+  protected Integer handle(
+      Project project, ProjectMetadata projectMetadata, List<SalesforceFunction> functions)
+      throws Exception {
     if (!Files.exists(bundlePath)) {
       Files.createDirectories(bundlePath);
     } else if (!Files.isDirectory(bundlePath)) {
@@ -49,7 +52,7 @@ class BundleCommandImpl extends AbstractDetectorCommandImpl {
       return MULTIPLE_FUNCTIONS_FOUND;
     }
 
-    FunctionBundler.bundle(project, functions.get(0), bundlePath);
+    FunctionBundler.bundle(projectPath, project, functions.get(0), bundlePath);
 
     return SUCCESS;
   }

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/BundleCommandImpl.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/BundleCommandImpl.java
@@ -11,7 +11,6 @@ import static com.salesforce.functions.jvm.runtime.commands.ExitCodes.*;
 import com.salesforce.functions.jvm.runtime.bundle.FunctionBundler;
 import com.salesforce.functions.jvm.runtime.project.Project;
 import com.salesforce.functions.jvm.runtime.project.ProjectBuilder;
-import com.salesforce.functions.jvm.runtime.project.ProjectMetadata;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.SalesforceFunction;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,9 +30,7 @@ class BundleCommandImpl extends AbstractDetectorCommandImpl {
   }
 
   @Override
-  protected Integer handle(
-      Project project, ProjectMetadata projectMetadata, List<SalesforceFunction> functions)
-      throws Exception {
+  protected Integer handle(Project project, List<SalesforceFunction> functions) throws Exception {
     if (!Files.exists(bundlePath)) {
       Files.createDirectories(bundlePath);
     } else if (!Files.isDirectory(bundlePath)) {

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ExitCodes.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ExitCodes.java
@@ -15,6 +15,7 @@ final class ExitCodes {
   public static final int BUNDLE_DIRECTORY_NOT_A_DIRECTORY = 5;
   public static final int UNEXPECTED_FILE_TYPE = 6;
   public static final int NO_PROJECT_FOUND = 7;
+  public static final int UNSUPPORTED_SALESFORCE_API_VERSION = 8;
   public static final int MISSING_OR_INVALID_ARGUMENTS = 250;
 
   private ExitCodes() {}

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ServeCommandImpl.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ServeCommandImpl.java
@@ -10,7 +10,6 @@ import com.salesforce.functions.jvm.runtime.InvocationInterface;
 import com.salesforce.functions.jvm.runtime.project.Project;
 import com.salesforce.functions.jvm.runtime.project.ProjectBuilder;
 import com.salesforce.functions.jvm.runtime.project.ProjectFunction;
-import com.salesforce.functions.jvm.runtime.project.ProjectMetadata;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.SalesforceFunction;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.SalesforceFunctionResult;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.SalesforceFunctionException;
@@ -37,9 +36,8 @@ class ServeCommandImpl extends AbstractDetectorCommandImpl {
     this.invocationInterface = invocationInterface;
   }
 
-  protected Integer handle(
-      Project project, ProjectMetadata projectMetadata, List<SalesforceFunction> functions)
-      throws Exception {
+  @Override
+  protected Integer handle(Project project, List<SalesforceFunction> functions) throws Exception {
     functions.forEach(function -> LOGGER.info("Found function: {}", function.getName()));
 
     ProjectFunction<CloudEvent, SalesforceFunctionResult, SalesforceFunctionException> function =

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ServeCommandImpl.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/commands/ServeCommandImpl.java
@@ -10,6 +10,7 @@ import com.salesforce.functions.jvm.runtime.InvocationInterface;
 import com.salesforce.functions.jvm.runtime.project.Project;
 import com.salesforce.functions.jvm.runtime.project.ProjectBuilder;
 import com.salesforce.functions.jvm.runtime.project.ProjectFunction;
+import com.salesforce.functions.jvm.runtime.project.ProjectMetadata;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.SalesforceFunction;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.SalesforceFunctionResult;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.SalesforceFunctionException;
@@ -36,7 +37,9 @@ class ServeCommandImpl extends AbstractDetectorCommandImpl {
     this.invocationInterface = invocationInterface;
   }
 
-  protected Integer handle(Project project, List<SalesforceFunction> functions) throws Exception {
+  protected Integer handle(
+      Project project, ProjectMetadata projectMetadata, List<SalesforceFunction> functions)
+      throws Exception {
     functions.forEach(function -> LOGGER.info("Found function: {}", function.getName()));
 
     ProjectFunction<CloudEvent, SalesforceFunctionResult, SalesforceFunctionException> function =

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadata.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2022, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadata.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadata.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.project;
+
+import java.util.Optional;
+
+public final class ProjectMetadata {
+  private final String salesforceApiVersion;
+
+  public ProjectMetadata(String salesforceApiVersion) {
+    this.salesforceApiVersion = salesforceApiVersion;
+  }
+
+  public Optional<String> getSalesforceApiVersion() {
+    return Optional.ofNullable(salesforceApiVersion);
+  }
+}

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadataParser.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadataParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2022, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadataParser.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadataParser.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.project;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.tomlj.Toml;
+import org.tomlj.TomlParseResult;
+
+public final class ProjectMetadataParser {
+
+  public static Optional<ProjectMetadata> parse(String projectTomlContents) {
+    return parse(Toml.parse(projectTomlContents));
+  }
+
+  public static Optional<ProjectMetadata> parse(Path projectTomlPath) throws IOException {
+    return parse(Toml.parse(projectTomlPath));
+  }
+
+  private static Optional<ProjectMetadata> parse(TomlParseResult result) {
+    if (result.hasErrors()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        new ProjectMetadata(result.getString("com.salesforce.salesforce-api-version")));
+  }
+}

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
@@ -6,14 +6,12 @@
  */
 package com.salesforce.functions.jvm.runtime.sfjavafunction;
 
-import com.salesforce.functions.jvm.runtime.Constants;
 import com.salesforce.functions.jvm.runtime.cloudevent.SalesforceContextCloudEventExtension;
 import com.salesforce.functions.jvm.runtime.cloudevent.SalesforceFunctionContextCloudEventExtension;
 import com.salesforce.functions.jvm.runtime.json.ListParameterizedType;
 import com.salesforce.functions.jvm.runtime.json.exception.AmbiguousJsonLibraryException;
 import com.salesforce.functions.jvm.runtime.project.Project;
 import com.salesforce.functions.jvm.runtime.project.ProjectFunctionsScanner;
-import com.salesforce.functions.jvm.runtime.project.ProjectMetadata;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.FunctionThrewExceptionException;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.SalesforceFunctionException;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.marshalling.*;
@@ -57,10 +55,10 @@ public class SalesforceFunctionsProjectFunctionsScanner
   private static final Pattern LIST_TYPE_STRING_PATTERN =
       Pattern.compile("java\\.util\\.List<(.*)>");
 
-  private final ProjectMetadata projectMetadata;
+  private final String salesforceApiVersion;
 
-  public SalesforceFunctionsProjectFunctionsScanner(ProjectMetadata projectMetadata) {
-    this.projectMetadata = projectMetadata;
+  public SalesforceFunctionsProjectFunctionsScanner(String salesforceApiVersion) {
+    this.salesforceApiVersion = salesforceApiVersion;
   }
 
   @Override
@@ -402,9 +400,7 @@ public class SalesforceFunctionsProjectFunctionsScanner
                                 cloudEvent,
                                 salesforceContext,
                                 functionContext,
-                                projectMetadata
-                                    .getSalesforceApiVersion()
-                                    .orElse(Constants.DEFAULT_SALESFORCE_API_VERSION));
+                                salesforceApiVersion);
                       } catch (InstantiationException
                           | IllegalAccessException
                           | InvocationTargetException e) {

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/commands/BundleCommandImplTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/commands/BundleCommandImplTest.java
@@ -13,15 +13,15 @@ import static org.mockito.Mockito.*;
 import com.salesforce.functions.jvm.runtime.project.Project;
 import com.salesforce.functions.jvm.runtime.project.ProjectBuilder;
 import com.salesforce.functions.jvm.runtime.test.Util;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -35,6 +35,15 @@ public class BundleCommandImplTest extends StdOutAndStdErrCapturingTest {
     this.sdkJarPath =
         Util.downloadFileToTemporary(
             "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-sdk-java/1.0.0/sf-fx-sdk-java-1.0.0.jar");
+  }
+
+  @Before
+  public void before() throws IOException {
+    File projectTomlFile = projectDirectoryFolder.newFile("project.toml");
+    Files.copy(
+        Paths.get("src", "test", "resources", "default-test-project.toml"),
+        projectTomlFile.toPath(),
+        StandardCopyOption.REPLACE_EXISTING);
   }
 
   @Test

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/commands/ServeCommandImplTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/commands/ServeCommandImplTest.java
@@ -18,13 +18,17 @@ import com.salesforce.functions.jvm.runtime.sfjavafunction.SalesforceFunctionRes
 import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.SalesforceFunctionException;
 import com.salesforce.functions.jvm.runtime.test.Util;
 import io.cloudevents.CloudEvent;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -37,6 +41,15 @@ public class ServeCommandImplTest extends StdOutAndStdErrCapturingTest {
     this.sdkJarPath =
         Util.downloadFileToTemporary(
             "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-sdk-java/1.0.0/sf-fx-sdk-java-1.0.0.jar");
+  }
+
+  @Before
+  public void before() throws IOException {
+    File projectTomlFile = projectDirectoryFolder.newFile("project.toml");
+    Files.copy(
+        Paths.get("src", "test", "resources", "default-test-project.toml"),
+        projectTomlFile.toPath(),
+        StandardCopyOption.REPLACE_EXISTING);
   }
 
   @Test

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadataParserTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadataParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2022, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadataParserTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/project/ProjectMetadataParserTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.project;
+
+import static com.spotify.hamcrest.optional.OptionalMatchers.emptyOptional;
+import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+
+public class ProjectMetadataParserTest {
+  @Test
+  public void testCanonicalExample() {
+    assertThat(
+        ProjectMetadataParser.parse(
+            "[_]\n"
+                + "schema-version = \"0.2\"\n"
+                + "[com.salesforce]\n"
+                + "schema-version = \"0.2\"\n"
+                + "id = \"template\"\n"
+                + "description = \"This is a Salesforce Function.\"\n"
+                + "type = \"function\"\n"
+                + "salesforce-api-version = \"55.0\"\n"),
+        is(
+            optionalWithValue(
+                hasProperty("salesforceApiVersion", optionalWithValue(equalTo("55.0"))))));
+  }
+
+  @Test
+  public void testModifiedExample() {
+    assertThat(
+        ProjectMetadataParser.parse("com.salesforce.salesforce-api-version = \"60.0\"\n"),
+        is(
+            optionalWithValue(
+                hasProperty("salesforceApiVersion", optionalWithValue(equalTo("60.0"))))));
+  }
+
+  @Test
+  public void testInvalidToml() {
+    assertThat(ProjectMetadataParser.parse("a ="), is(emptyOptional()));
+  }
+
+  @Test
+  public void testMissingSalesforceApiVersion() {
+    assertThat(
+        ProjectMetadataParser.parse(
+            "[_]\n"
+                + "schema-version = \"0.2\"\n"
+                + "[com.salesforce]\n"
+                + "schema-version = \"0.2\"\n"
+                + "id = \"template\"\n"
+                + "description = \"This is a Salesforce Function.\"\n"
+                + "type = \"function\"\n"),
+        is(optionalWithValue(hasProperty("salesforceApiVersion", emptyOptional()))));
+  }
+}

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScannerTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScannerTest.java
@@ -13,12 +13,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.net.MediaType;
+import com.salesforce.functions.jvm.runtime.Constants;
 import com.salesforce.functions.jvm.runtime.cloudevent.SalesforceCloudEventExtensionParser;
 import com.salesforce.functions.jvm.runtime.cloudevent.SalesforceContextCloudEventExtension;
 import com.salesforce.functions.jvm.runtime.cloudevent.SalesforceFunctionContextCloudEventExtension;
 import com.salesforce.functions.jvm.runtime.cloudevent.UserContext;
 import com.salesforce.functions.jvm.runtime.commands.StdOutAndStdErrCapturingTest;
 import com.salesforce.functions.jvm.runtime.project.Project;
+import com.salesforce.functions.jvm.runtime.project.ProjectMetadata;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.FunctionThrewExceptionException;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.marshalling.ByteArrayPayloadUnmarshaller;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.marshalling.JsonFunctionResultMarshaller;
@@ -69,7 +71,8 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testSuccessPojoInStringOutFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner();
+        new SalesforceFunctionsProjectFunctionsScanner(
+            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -104,7 +107,8 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testSuccessBytesInPojoOutFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner();
+        new SalesforceFunctionsProjectFunctionsScanner(
+            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -136,7 +140,8 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testSuccessJoinStringListFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner();
+        new SalesforceFunctionsProjectFunctionsScanner(
+            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -147,6 +152,9 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
     when(mockProject.getClasspathPaths()).thenReturn(paths);
 
     List<SalesforceFunction> functions = scanner.scan(mockProject);
+
+    assertThat(functions, hasSize(1));
+
     assertThat(
         functions,
         contains(
@@ -171,7 +179,8 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testSuccessUppercaseListOfStringsFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner();
+        new SalesforceFunctionsProjectFunctionsScanner(
+            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -207,7 +216,8 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testFailingFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner();
+        new SalesforceFunctionsProjectFunctionsScanner(
+            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -349,7 +359,8 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   private List<SalesforceFunction> scanTestFunctionDirectory(
       String functionDirectory, Path... classpathJarFiles) {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner();
+        new SalesforceFunctionsProjectFunctionsScanner(
+            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
 
     List<Path> paths = new ArrayList<>();
     paths.add(Paths.get("src", "test", "resources", functionDirectory));

--- a/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScannerTest.java
+++ b/sf-fx-runtime-java-runtime/src/test/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScannerTest.java
@@ -20,7 +20,6 @@ import com.salesforce.functions.jvm.runtime.cloudevent.SalesforceFunctionContext
 import com.salesforce.functions.jvm.runtime.cloudevent.UserContext;
 import com.salesforce.functions.jvm.runtime.commands.StdOutAndStdErrCapturingTest;
 import com.salesforce.functions.jvm.runtime.project.Project;
-import com.salesforce.functions.jvm.runtime.project.ProjectMetadata;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.exception.FunctionThrewExceptionException;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.marshalling.ByteArrayPayloadUnmarshaller;
 import com.salesforce.functions.jvm.runtime.sfjavafunction.marshalling.JsonFunctionResultMarshaller;
@@ -71,8 +70,7 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testSuccessPojoInStringOutFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner(
-            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
+        new SalesforceFunctionsProjectFunctionsScanner(Constants.DEFAULT_SALESFORCE_API_VERSION);
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -107,8 +105,7 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testSuccessBytesInPojoOutFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner(
-            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
+        new SalesforceFunctionsProjectFunctionsScanner(Constants.DEFAULT_SALESFORCE_API_VERSION);
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -140,8 +137,7 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testSuccessJoinStringListFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner(
-            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
+        new SalesforceFunctionsProjectFunctionsScanner(Constants.DEFAULT_SALESFORCE_API_VERSION);
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -179,8 +175,7 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testSuccessUppercaseListOfStringsFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner(
-            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
+        new SalesforceFunctionsProjectFunctionsScanner(Constants.DEFAULT_SALESFORCE_API_VERSION);
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -216,8 +211,7 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   @Test
   public void testFailingFunction() {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner(
-            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
+        new SalesforceFunctionsProjectFunctionsScanner(Constants.DEFAULT_SALESFORCE_API_VERSION);
 
     List<Path> paths = new ArrayList<>();
     paths.add(sdkJarPath);
@@ -359,8 +353,7 @@ public class SalesforceFunctionsProjectFunctionsScannerTest extends StdOutAndStd
   private List<SalesforceFunction> scanTestFunctionDirectory(
       String functionDirectory, Path... classpathJarFiles) {
     SalesforceFunctionsProjectFunctionsScanner scanner =
-        new SalesforceFunctionsProjectFunctionsScanner(
-            new ProjectMetadata(Constants.DEFAULT_SALESFORCE_API_VERSION));
+        new SalesforceFunctionsProjectFunctionsScanner(Constants.DEFAULT_SALESFORCE_API_VERSION);
 
     List<Path> paths = new ArrayList<>();
     paths.add(Paths.get("src", "test", "resources", functionDirectory));

--- a/sf-fx-runtime-java-runtime/src/test/resources/default-test-project.toml
+++ b/sf-fx-runtime-java-runtime/src/test/resources/default-test-project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "template"
+description = "This is a Salesforce Function."
+type = "function"
+salesforce-api-version = "53.0"

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/ContextImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/ContextImpl.java
@@ -22,9 +22,10 @@ public class ContextImpl implements Context {
   public ContextImpl(
       CloudEvent cloudEvent,
       SalesforceContextCloudEventExtension salesforceContext,
-      SalesforceFunctionContextCloudEventExtension functionContext) {
+      SalesforceFunctionContextCloudEventExtension functionContext,
+      String apiVersion) {
     this.cloudEvent = cloudEvent;
-    this.org = new OrgImpl(salesforceContext, functionContext);
+    this.org = new OrgImpl(salesforceContext, functionContext, apiVersion);
   }
 
   @Override

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/OrgImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/OrgImpl.java
@@ -14,13 +14,16 @@ import java.net.URI;
 import javax.annotation.Nonnull;
 
 public class OrgImpl implements Org {
+  private final String apiVersion;
   private final SalesforceContextCloudEventExtension salesforceContext;
   private final UserImpl user;
   private final DataApiImpl dataApi;
 
   public OrgImpl(
       SalesforceContextCloudEventExtension salesforceContext,
-      SalesforceFunctionContextCloudEventExtension functionContext) {
+      SalesforceFunctionContextCloudEventExtension functionContext,
+      String apiVersion) {
+    this.apiVersion = apiVersion;
     this.salesforceContext = salesforceContext;
     this.dataApi =
         new DataApiImpl(this.getBaseUrl(), this.getApiVersion(), functionContext.getAccessToken());
@@ -48,10 +51,7 @@ public class OrgImpl implements Org {
   @Override
   @Nonnull
   public String getApiVersion() {
-    // An API version is also available in the context via #getApiVersion(). That value differs
-    // between orgs and can change seemingly randomly. To avoid surprises at runtime, we
-    // intentionally don't use that value and instead fix the version.
-    return "53.0";
+    return this.apiVersion;
   }
 
   @Override

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/ContextImplTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/ContextImplTest.java
@@ -64,7 +64,8 @@ public class ContextImplTest {
 
   @Test
   public void testContextValues() {
-    Context context = new ContextImpl(cloudEvent, contextExtension, functionContextExtension);
+    Context context =
+        new ContextImpl(cloudEvent, contextExtension, functionContextExtension, "53.0");
 
     assertThat(context.getId(), is(equalTo(cloudEvent.getId())));
     assertThat(context.getOrg(), is(optionalWithValue()));
@@ -72,7 +73,7 @@ public class ContextImplTest {
 
   @Test
   public void testOrgValues() {
-    Org org = new OrgImpl(contextExtension, functionContextExtension);
+    Org org = new OrgImpl(contextExtension, functionContextExtension, "53.0");
 
     assertThat(org.getId(), is(equalTo(contextExtension.getUserContext().getOrgId())));
     assertThat(


### PR DESCRIPTION
Implements Salesforce API version pinning, similar to https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/276. It can be used with a configuration like this:

```toml
# project.toml
[com.salesforce]
salesforce-api-version = "53.0"
```

Functions that do not have `salesforce-api-version` defined will be defaulted to `53.0` and be shown a deprecation warning. Functions that specify anything other `53.0` will fail with an error. Note that this PR does not add support for any other version than `53.0`, support for `54.0` will be added in a separate PR.

Implements https://salesforce.quip.com/auYwAHFJLoNy.

Sample output when using the implicit default version:

```
13:42:50.383 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Detecting project type at path /Users/manuel.fuchs/projects/sf-fx-template-java...
13:42:52.533 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Detected Maven project at path /Users/manuel.fuchs/projects/sf-fx-template-java after 2148ms!
13:42:52.533 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Reading project metadata at path /Users/manuel.fuchs/projects/sf-fx-template-java...
13:42:52.597 WARN  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Project Salesforce API version isn't explicitly defined in project.toml. The default version 53.0 will be used.
13:42:52.598 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Project uses Salesforce API version 53.0.
13:42:52.598 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Scanning project for functions...
```

Sample output when using and explicitly configured version:

```
13:44:48.876 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Detecting project type at path /Users/manuel.fuchs/projects/sf-fx-template-java...
13:44:50.778 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Detected Maven project at path /Users/manuel.fuchs/projects/sf-fx-template-java after 1900ms!
13:44:50.778 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Reading project metadata at path /Users/manuel.fuchs/projects/sf-fx-template-java...
13:44:50.849 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Project uses Salesforce API version 60.0.
13:44:50.849 INFO  [RUNTIME] c.s.f.j.r.c.AbstractDetectorCommandImpl - Scanning project for functions...
```