### PR TITLE
Add nested query results support to REST API module

### DIFF
--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/AbstractQueryRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/AbstractQueryRestApiRequest.java
@@ -17,55 +17,61 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractQueryRestApiRequest implements RestApiRequest<QueryRecordResult> {
+  private final Gson gson = new Gson();
 
   @Override
   public final QueryRecordResult processResponse(
       int statusCode, Map<String, String> headers, JsonElement json) throws RestApiErrorsException {
 
-    final Gson gson = new Gson();
-
     if (statusCode != 200) {
       throw new RestApiErrorsException(ErrorResponseParser.parse(json));
     } else {
-      final JsonObject body = json.getAsJsonObject();
-      final boolean done = body.get("done").getAsBoolean();
-      final long totalSize = body.get("totalSize").getAsLong();
-      final List<Record> records = new ArrayList<>();
+      return parseQueryResult(json.getAsJsonObject());
+    }
+  }
 
-      final String nextRecordsPath;
-      if (body.get("nextRecordsUrl") == null || body.get("nextRecordsUrl").isJsonNull()) {
-        nextRecordsPath = null;
-      } else {
-        nextRecordsPath = body.get("nextRecordsUrl").getAsString();
-      }
+  private QueryRecordResult parseQueryResult(JsonObject body) {
+    final boolean done = body.get("done").getAsBoolean();
+    final long totalSize = body.get("totalSize").getAsLong();
+    final List<Record> records = new ArrayList<>();
 
-      for (JsonElement jsonElement : body.get("records").getAsJsonArray()) {
-        final JsonObject jsonObject = jsonElement.getAsJsonObject();
+    final String nextRecordsPath;
+    if (body.get("nextRecordsUrl") == null || body.get("nextRecordsUrl").isJsonNull()) {
+      nextRecordsPath = null;
+    } else {
+      nextRecordsPath = body.get("nextRecordsUrl").getAsString();
+    }
 
-        final JsonObject attributesObject = jsonObject.get("attributes").getAsJsonObject();
-        final Map<String, JsonPrimitive> attributes =
-            gson.fromJson(
-                attributesObject, new TypeToken<Map<String, JsonPrimitive>>() {}.getType());
+    for (JsonElement jsonElement : body.get("records").getAsJsonArray()) {
+      final JsonObject jsonObject = jsonElement.getAsJsonObject();
 
-        final Map<String, JsonPrimitive> values = new HashMap<>();
-        for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
-          if (entry.getKey().equals("attributes")) {
-            continue;
-          }
+      final JsonObject attributesObject = jsonObject.get("attributes").getAsJsonObject();
+      final Map<String, JsonPrimitive> attributes =
+          gson.fromJson(attributesObject, new TypeToken<Map<String, JsonPrimitive>>() {}.getType());
 
-          if (entry.getValue().isJsonPrimitive()) {
-            values.put(entry.getKey(), entry.getValue().getAsJsonPrimitive());
-          } else if (entry.getValue().isJsonNull()) {
-            // We don't add the value if it's null.
-          } else {
+      final Map<String, JsonPrimitive> values = new HashMap<>();
+      final Map<String, QueryRecordResult> subQueryResults = new HashMap<>();
+
+      for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+        if (entry.getKey().equals("attributes")) {
+          continue;
+        }
+
+        if (entry.getValue().isJsonPrimitive()) {
+          values.put(entry.getKey(), entry.getValue().getAsJsonPrimitive());
+        } else if (entry.getValue().isJsonObject()) {
+          subQueryResults.put(entry.getKey(), parseQueryResult(entry.getValue().getAsJsonObject()));
+        } else {
+          // We don't throw an exception if the value is null, but it will not be added.
+          if (!entry.getValue().isJsonNull()) {
             throw new RuntimeException("Unexpected value in record response: " + entry.getValue());
           }
         }
-
-        records.add(new Record(attributes, values));
       }
 
-      return new QueryRecordResult(totalSize, done, records, nextRecordsPath);
+      records.add(new Record(attributes, values, subQueryResults));
     }
+
+    return new QueryRecordResult(totalSize, done, records, nextRecordsPath);
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResult.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResult.java
@@ -7,6 +7,7 @@
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
 import java.util.*;
+import javax.annotation.Nullable;
 
 public final class QueryRecordResult {
   private final long totalSize;
@@ -15,7 +16,7 @@ public final class QueryRecordResult {
   private final String nextRecordsPath;
 
   public QueryRecordResult(
-      long totalSize, boolean done, List<Record> records, String nextRecordsPath) {
+      long totalSize, boolean done, List<Record> records, @Nullable String nextRecordsPath) {
     this.totalSize = totalSize;
     this.done = done;
     this.records = new ArrayList<>(records);
@@ -56,5 +57,20 @@ public final class QueryRecordResult {
   @Override
   public int hashCode() {
     return Objects.hash(totalSize, done, records, nextRecordsPath);
+  }
+
+  @Override
+  public String toString() {
+    return "QueryRecordResult{"
+        + "totalSize="
+        + totalSize
+        + ", done="
+        + done
+        + ", records="
+        + records
+        + ", nextRecordsPath='"
+        + nextRecordsPath
+        + '\''
+        + '}';
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/Record.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/Record.java
@@ -15,10 +15,15 @@ import javax.annotation.Nonnull;
 public final class Record {
   private final Map<String, JsonPrimitive> attributes;
   private final Map<String, JsonPrimitive> values;
+  private final Map<String, QueryRecordResult> subQueryResults;
 
-  public Record(Map<String, JsonPrimitive> attributes, Map<String, JsonPrimitive> values) {
+  public Record(
+      Map<String, JsonPrimitive> attributes,
+      Map<String, JsonPrimitive> values,
+      Map<String, QueryRecordResult> subQueryResults) {
     this.attributes = attributes;
     this.values = values;
+    this.subQueryResults = subQueryResults;
   }
 
   @Nonnull
@@ -31,20 +36,35 @@ public final class Record {
     return Collections.unmodifiableMap(values);
   }
 
+  @Nonnull
+  public Map<String, QueryRecordResult> getSubQueryResults() {
+    return Collections.unmodifiableMap(subQueryResults);
+  }
+
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
     Record record = (Record) o;
-    return attributes.equals(record.attributes) && values.equals(record.values);
+    return Objects.equals(attributes, record.attributes)
+        && Objects.equals(values, record.values)
+        && Objects.equals(subQueryResults, record.subQueryResults);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(attributes, values);
+    return Objects.hash(attributes, values, subQueryResults);
+  }
+
+  @Override
+  public String toString() {
+    return "Record{"
+        + "attributes="
+        + attributes
+        + ", values="
+        + values
+        + ", subQueryResults="
+        + subQueryResults
+        + '}';
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResultTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResultTest.java
@@ -6,6 +6,9 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
+import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.jsonPrimitiveMap;
+
+import java.util.Collections;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
@@ -13,6 +16,27 @@ public class QueryRecordResultTest {
 
   @Test
   public void testEqualsAndHashCode() {
-    EqualsVerifier.forClass(QueryRecordResult.class).verify();
+    Record red =
+        new Record(
+            jsonPrimitiveMap(
+                new RecordBuilder.JsonPrimitiveTuple("type", "Account"),
+                new RecordBuilder.JsonPrimitiveTuple(
+                    "url", "/services/data/v53.0/sobjects/Account/001B000001LwihuIAB")),
+            jsonPrimitiveMap(new RecordBuilder.JsonPrimitiveTuple("Name", "Acme")),
+            Collections.emptyMap());
+
+    Record blue =
+        new Record(
+            jsonPrimitiveMap(
+                new RecordBuilder.JsonPrimitiveTuple("type", "Account"),
+                new RecordBuilder.JsonPrimitiveTuple(
+                    "url", "/services/data/v53.0/sobjects/Account/001B000001LnobCIAR")),
+            jsonPrimitiveMap(
+                new RecordBuilder.JsonPrimitiveTuple("Name", "Sample Account for Entitlements")),
+            Collections.emptyMap());
+
+    EqualsVerifier.forClass(QueryRecordResult.class)
+        .withPrefabValues(Record.class, red, blue)
+        .verify();
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordBuilder.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordBuilder.java
@@ -11,35 +11,62 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class RecordBuilder {
-  public static Map<String, JsonPrimitive> map(Tuple... data) {
+  public static Map<String, JsonPrimitive> jsonPrimitiveMap(JsonPrimitiveTuple... data) {
     HashMap<String, JsonPrimitive> result = new HashMap<>();
-    for (Tuple tuple : data) {
+    for (JsonPrimitiveTuple tuple : data) {
       result.put(tuple.getKey(), tuple.getValue());
     }
 
     return result;
   }
 
-  public static class Tuple {
+  public static Map<String, QueryRecordResult> queryResultMap(QueryResultTuple... data) {
+    HashMap<String, QueryRecordResult> result = new HashMap<>();
+    for (QueryResultTuple tuple : data) {
+      result.put(tuple.getKey(), tuple.getValue());
+    }
+
+    return result;
+  }
+
+  public static class QueryResultTuple {
+    private final String key;
+    private final QueryRecordResult value;
+
+    public QueryResultTuple(String key, QueryRecordResult value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public QueryRecordResult getValue() {
+      return value;
+    }
+  }
+
+  public static class JsonPrimitiveTuple {
     private final String key;
     private final JsonPrimitive value;
 
-    public Tuple(String key, String value) {
+    public JsonPrimitiveTuple(String key, String value) {
       this.key = key;
       this.value = new JsonPrimitive(value);
     }
 
-    public Tuple(String key, Number value) {
+    public JsonPrimitiveTuple(String key, Number value) {
       this.key = key;
       this.value = new JsonPrimitive(value);
     }
 
-    public Tuple(String key, Boolean value) {
+    public JsonPrimitiveTuple(String key, Boolean value) {
       this.key = key;
       this.value = new JsonPrimitive(value);
     }
 
-    public Tuple(String key, Character value) {
+    public JsonPrimitiveTuple(String key, Character value) {
       this.key = key;
       this.value = new JsonPrimitive(value);
     }

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
@@ -6,11 +6,13 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
+import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.jsonPrimitiveMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.google.gson.JsonPrimitive;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -21,17 +23,40 @@ public class RecordTest {
   @Test
   public void testValuesAndAttributesAreUnmodified() {
     Map<String, JsonPrimitive> attributes = new HashMap<>();
+
     Map<String, JsonPrimitive> values = new HashMap<>();
     values.put("foo", new JsonPrimitive("bar"));
     values.put("bar", new JsonPrimitive("baz"));
 
-    Record record = new Record(attributes, values);
+    Map<String, QueryRecordResult> subQueryResults = new HashMap<>();
+
+    Record record = new Record(attributes, values, subQueryResults);
     assertThat(record.getAttributes(), is(equalTo(attributes)));
     assertThat(record.getValues(), is(equalTo(values)));
+    assertThat(record.getSubQueryResults(), is(equalTo(subQueryResults)));
   }
 
   @Test
   public void testEqualsAndHashCode() {
-    EqualsVerifier.forClass(Record.class).verify();
+    Record red =
+        new Record(
+            jsonPrimitiveMap(
+                new RecordBuilder.JsonPrimitiveTuple("type", "Account"),
+                new RecordBuilder.JsonPrimitiveTuple(
+                    "url", "/services/data/v53.0/sobjects/Account/001B000001LwihuIAB")),
+            jsonPrimitiveMap(new RecordBuilder.JsonPrimitiveTuple("Name", "Acme")),
+            Collections.emptyMap());
+
+    Record blue =
+        new Record(
+            jsonPrimitiveMap(
+                new RecordBuilder.JsonPrimitiveTuple("type", "Account"),
+                new RecordBuilder.JsonPrimitiveTuple(
+                    "url", "/services/data/v53.0/sobjects/Account/001B000001LnobCIAR")),
+            jsonPrimitiveMap(
+                new RecordBuilder.JsonPrimitiveTuple("Name", "Sample Account for Entitlements")),
+            Collections.emptyMap());
+
+    EqualsVerifier.forClass(Record.class).withPrefabValues(Record.class, red, blue).verify();
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/query-with-subquery.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/query-with-subquery.json
@@ -1,0 +1,40 @@
+{
+  "id" : "ecf16e4b-f058-4802-b44d-2c77b1e49aa1",
+  "name" : "services_data_v510_query",
+  "request" : {
+    "urlPath" : "/services/data/v53.0/query",
+    "method" : "GET",
+    "queryParameters" : {
+      "q": {
+        "equalTo": "SELECT Account.Name, (SELECT Contact.FirstName, Contact.LastName FROM Account.Contacts) FROM Account LIMIT 5"
+      }
+    },
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"totalSize\":5,\"done\":true,\"records\":[{\"attributes\":{\"type\":\"Account\",\"url\":\"/services/data/v53.0/sobjects/Account/0017Q00000EZlbyQAD\"},\"Name\":\"GenePoint\",\"Contacts\":{\"totalSize\":1,\"done\":true,\"records\":[{\"attributes\":{\"type\":\"Contact\",\"url\":\"/services/data/v53.0/sobjects/Contact/0037Q000007vKjpQAE\"},\"FirstName\":\"Edna\",\"LastName\":\"Frank\"}]}},{\"attributes\":{\"type\":\"Account\",\"url\":\"/services/data/v53.0/sobjects/Account/0017Q00000EZlbwQAD\"},\"Name\":\"United Oil & Gas, UK\",\"Contacts\":{\"totalSize\":1,\"done\":true,\"records\":[{\"attributes\":{\"type\":\"Contact\",\"url\":\"/services/data/v53.0/sobjects/Contact/0037Q000007vKjmQAE\"},\"FirstName\":\"Ashley\",\"LastName\":\"James\"}]}},{\"attributes\":{\"type\":\"Account\",\"url\":\"/services/data/v53.0/sobjects/Account/0017Q00000EZlbxQAD\"},\"Name\":\"United Oil & Gas, Singapore\",\"Contacts\":{\"totalSize\":2,\"done\":true,\"records\":[{\"attributes\":{\"type\":\"Contact\",\"url\":\"/services/data/v53.0/sobjects/Contact/0037Q000007vKjnQAE\"},\"FirstName\":\"Tom\",\"LastName\":\"Ripley\"},{\"attributes\":{\"type\":\"Contact\",\"url\":\"/services/data/v53.0/sobjects/Contact/0037Q000007vKjoQAE\"},\"FirstName\":\"Liz\",\"LastName\":\"D'Cruz\"}]}},{\"attributes\":{\"type\":\"Account\",\"url\":\"/services/data/v53.0/sobjects/Account/0017Q00000EZlboQAD\"},\"Name\":\"Edge Communications\",\"Contacts\":{\"totalSize\":2,\"done\":true,\"records\":[{\"attributes\":{\"type\":\"Contact\",\"url\":\"/services/data/v53.0/sobjects/Contact/0037Q000007vKjZQAU\"},\"FirstName\":\"Rose\",\"LastName\":\"Gonzalez\"},{\"attributes\":{\"type\":\"Contact\",\"url\":\"/services/data/v53.0/sobjects/Contact/0037Q000007vKjaQAE\"},\"FirstName\":\"Sean\",\"LastName\":\"Forbes\"}]}},{\"attributes\":{\"type\":\"Account\",\"url\":\"/services/data/v53.0/sobjects/Account/0017Q00000EZlbpQAD\"},\"Name\":\"Burlington Textiles Corp of America\",\"Contacts\":{\"totalSize\":1,\"done\":true,\"records\":[{\"attributes\":{\"type\":\"Contact\",\"url\":\"/services/data/v53.0/sobjects/Contact/0037Q000007vKjbQAE\"},\"FirstName\":\"Jack\",\"LastName\":\"Rogers\"}]}}]}",
+    "headers" : {
+      "Date" : "Tue, 13 Apr 2021 11:33:05 GMT",
+      "Strict-Transport-Security" : "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : [ "BrowserId=A2CSeZxMEeu0AYlXSkrHVQ; domain=.salesforce.com; path=/; expires=Wed, 13-Apr-2022 11:33:05 GMT; Max-Age=31536000", "BrowserId_sec=A2CSeZxMEeu0AYlXSkrHVQ; domain=.salesforce.com; path=/; expires=Wed, 13-Apr-2022 11:33:05 GMT; Max-Age=31536000; secure; SameSite=None" ],
+      "Sforce-Limit-Info" : "api-usage=16/100000",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "ecf16e4b-f058-4802-b44d-2c77b1e49aa1",
+  "persistent" : true,
+  "insertionIndex" : 1
+}


### PR DESCRIPTION
Add nested query results support to REST API module. Nested results will be returned when users use a SOQL query that contains [relationship queries](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_relationships_query_using.htm#sforce_api_calls_soql_relationships_query_using).

This PR adds support for these to the underlying REST API module only. The feature that exposes this data via the SDK will be implemented separately.

Closes GUS-W-11381383