### PR TITLE
Use curl retries instead of sleeping in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,16 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.0.2
-  windows: circleci/windows@2.4.1
+  codecov: codecov/codecov@3.2.3
+  windows: circleci/windows@4.1.1
 
 executors:
   openjdk-8:
     docker:
-      - image: circleci/openjdk:8
+      - image: cimg/openjdk:8.0
   openjdk-11:
     docker:
-      - image: circleci/openjdk:11
+      - image: cimg/openjdk:11.0
 
 jobs:
   maven:

--- a/integration-test/openjdk-11/exception/test.sh
+++ b/integration-test/openjdk-11/exception/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '"Hello World!"' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-11/list-pojo/test.sh
+++ b/integration-test/openjdk-11/list-pojo/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '[{"name": "Jonas", age: 0}, {"name": "Johanna", age: 5}]' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-11/pojo-gson/test.sh
+++ b/integration-test/openjdk-11/pojo-gson/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '{"name": "Johanna", age: 5}' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-11/pojo-jackson/test.sh
+++ b/integration-test/openjdk-11/pojo-jackson/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '{"name": "Katrin", age: 36}' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-11/pojo/test.sh
+++ b/integration-test/openjdk-11/pojo/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '{"name": "Jonas", age: 0}' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-11/string-reverse/test.sh
+++ b/integration-test/openjdk-11/string-reverse/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '"Hello World!"' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-8/exception/test.sh
+++ b/integration-test/openjdk-8/exception/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '"Hello World!"' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-8/list-pojo/test.sh
+++ b/integration-test/openjdk-8/list-pojo/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '[{"name": "Jonas", age: 0}, {"name": "Johanna", age: 5}]' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-8/pojo-gson/test.sh
+++ b/integration-test/openjdk-8/pojo-gson/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '{"name": "Johanna", age: 5}' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-8/pojo-jackson/test.sh
+++ b/integration-test/openjdk-8/pojo-jackson/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '{"name": "Katrin", age: 36}' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-8/pojo/test.sh
+++ b/integration-test/openjdk-8/pojo/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '{"name": "Jonas", age: 0}' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \

--- a/integration-test/openjdk-8/string-reverse/test.sh
+++ b/integration-test/openjdk-8/string-reverse/test.sh
@@ -14,12 +14,11 @@ popd
 "${test_dir}"/../../../sf-fx-runtime-java serve -p "${port}" "${test_dir}" >"${runtime_output_logfile}" &
 runtime_pid=$!
 
-# The curl version used by CircleCI does not correctly support curl's --retry-connrefused
-# which would work around having this fixed sleep in here. We should revisit this code in the future
-# to see if we can get rid of this sleep then.
-sleep 5
-
 curl "http://localhost:${port}" \
+	--connect-timeout 3 \
+	--retry 3 \
+	--retry-all-errors \
+	--fail \
 	-d '"Hello World!"' \
 	-H "Content-Type: application/json" \
 	-H "ce-specversion: 1.0" \


### PR DESCRIPTION
Newer Circle CI images contain curl that supports `--retry-connrefused`, so it's no longer necessary to use the workaround of `sleep`ing.

In addition, `--fail` has been added to the test curl calls, to ensure the test verifies that the function server response was an HTTP 200.