### PR TITLE
SDK 1.1: Binary Fields

### DIFF
--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/BinaryFieldUtil.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/BinaryFieldUtil.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryRecordResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.Record;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.*;
+
+final class BinaryFieldUtil {
+  public static boolean isBinaryField(String objectType, String fieldName) {
+    Map<String, List<String>> mapping = new HashMap<>();
+    mapping.put("ContentVersion", Collections.singletonList("VersionData"));
+
+    return Optional.ofNullable(mapping.get(objectType))
+        .map(fieldList -> fieldList.contains(fieldName))
+        .orElse(false);
+  }
+
+  public static RecordQueryResultImpl convert(QueryRecordResult queryRecordResult, RestApi restApi)
+      throws URISyntaxException, IOException {
+    List<RecordWithSubQueryResultsImpl> records = new ArrayList<>();
+    for (Record record : queryRecordResult.getRecords()) {
+      records.add(convert(record, restApi));
+    }
+
+    return new RecordQueryResultImpl(
+        queryRecordResult.isDone(),
+        queryRecordResult.getTotalSize(),
+        queryRecordResult.getNextRecordsPath(),
+        records);
+  }
+
+  public static RecordWithSubQueryResultsImpl convert(Record record, RestApi restApi)
+      throws URISyntaxException, IOException {
+    final String recordObjectType = record.getAttributes().get("type").getAsString();
+
+    final Map<String, FieldValue> fieldValues = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    for (Map.Entry<String, JsonPrimitive> fieldEntry : record.getValues().entrySet()) {
+      FieldValue fieldValue = new FieldValue(fieldEntry.getValue());
+
+      if (isBinaryField(recordObjectType, fieldEntry.getKey())) {
+        ByteBuffer data = restApi.downloadFile(fieldEntry.getValue().getAsString());
+        fieldValue = new FieldValue(data);
+      }
+
+      fieldValues.put(fieldEntry.getKey(), fieldValue);
+    }
+
+    final Map<String, RecordQueryResultImpl> subQueryResults = new HashMap<>();
+    for (Map.Entry<String, QueryRecordResult> entry : record.getSubQueryResults().entrySet()) {
+      subQueryResults.put(entry.getKey(), convert(entry.getValue(), restApi));
+    }
+
+    return new RecordWithSubQueryResultsImpl(recordObjectType, fieldValues, subQueryResults);
+  }
+
+  public static Map<String, JsonElement> convert(Map<String, FieldValue> fieldValues2) {
+    Map<String, JsonElement> fieldValues = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    for (Map.Entry<String, FieldValue> entry : fieldValues2.entrySet()) {
+      if (entry.getValue().isBinaryData()) {
+        fieldValues.put(
+            entry.getKey(),
+            new JsonPrimitive(
+                Base64.getEncoder().encodeToString(entry.getValue().getBinaryData().array())));
+      } else {
+        fieldValues.put(entry.getKey(), entry.getValue().getJsonData());
+      }
+    }
+
+    return fieldValues;
+  }
+
+  private BinaryFieldUtil() {}
+}

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/EmptyRecordQueryResultImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/EmptyRecordQueryResultImpl.java
@@ -6,7 +6,6 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryRecordResult;
 import com.salesforce.functions.jvm.sdk.data.RecordQueryResult;
 import com.salesforce.functions.jvm.sdk.data.RecordWithSubQueryResults;
 import java.util.Collections;
@@ -14,20 +13,22 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 public class EmptyRecordQueryResultImpl implements RecordQueryResult {
-  private final QueryRecordResult queryRecordResult;
+  private final boolean done;
+  private final long totalSize;
 
-  public EmptyRecordQueryResultImpl(QueryRecordResult queryRecordResult) {
-    this.queryRecordResult = queryRecordResult;
+  public EmptyRecordQueryResultImpl(boolean done, long totalSize) {
+    this.done = done;
+    this.totalSize = totalSize;
   }
 
   @Override
   public boolean isDone() {
-    return queryRecordResult.isDone();
+    return done;
   }
 
   @Override
   public long getTotalSize() {
-    return queryRecordResult.getTotalSize();
+    return totalSize;
   }
 
   @Nonnull

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/FieldValue.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/FieldValue.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk;
+
+import com.google.gson.JsonElement;
+import java.nio.ByteBuffer;
+import javax.annotation.Nonnull;
+
+public class FieldValue {
+  private final JsonElement jsonData;
+  private final ByteBuffer binaryData;
+
+  public FieldValue(@Nonnull JsonElement jsonData) {
+    this.jsonData = jsonData;
+    this.binaryData = null;
+  }
+
+  public FieldValue(@Nonnull ByteBuffer binaryData) {
+    this.binaryData = binaryData;
+    this.jsonData = null;
+  }
+
+  public boolean isBinaryData() {
+    return this.binaryData != null;
+  }
+
+  public boolean isJsonData() {
+    return this.jsonData != null;
+  }
+
+  public JsonElement getJsonData() {
+    return jsonData;
+  }
+
+  public ByteBuffer getBinaryData() {
+    return binaryData;
+  }
+
+  @Override
+  public String toString() {
+    return "FieldValue{" + "jsonData=" + jsonData + ", binaryData=" + binaryData + '}';
+  }
+}

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordBuilderImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordBuilderImpl.java
@@ -6,7 +6,6 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
 import com.salesforce.functions.jvm.sdk.data.Record;
@@ -14,20 +13,21 @@ import com.salesforce.functions.jvm.sdk.data.ReferenceId;
 import com.salesforce.functions.jvm.sdk.data.builder.RecordBuilder;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class RecordBuilderImpl extends AbstractRecordAccessorImpl implements RecordBuilder {
-  private final TreeMap<String, JsonElement> fieldValues =
+  private final TreeMap<String, FieldValue> fieldValues =
       new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
   public RecordBuilderImpl(String type) {
     super(type);
   }
 
-  public RecordBuilderImpl(String type, Map<String, JsonElement> fieldValues) {
+  public RecordBuilderImpl(String type, Map<String, FieldValue> fieldValues) {
     super(type);
     this.fieldValues.putAll(fieldValues);
   }
@@ -48,7 +48,7 @@ public class RecordBuilderImpl extends AbstractRecordAccessorImpl implements Rec
   @Nonnull
   @Override
   public RecordBuilder withNullField(String name) {
-    fieldValues.put(name, JsonNull.INSTANCE);
+    fieldValues.put(name, new FieldValue(JsonNull.INSTANCE));
     return this;
   }
 
@@ -59,56 +59,56 @@ public class RecordBuilderImpl extends AbstractRecordAccessorImpl implements Rec
       return withNullField(name);
     }
 
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
   @Nonnull
   @Override
   public RecordBuilder withField(String name, short value) {
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
   @Nonnull
   @Override
   public RecordBuilder withField(String name, long value) {
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
   @Nonnull
   @Override
   public RecordBuilder withField(String name, int value) {
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
   @Nonnull
   @Override
   public RecordBuilder withField(String name, float value) {
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
   @Nonnull
   @Override
   public RecordBuilder withField(String name, double value) {
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
   @Nonnull
   @Override
   public RecordBuilder withField(String name, byte value) {
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
   @Nonnull
   @Override
   public RecordBuilder withField(String name, boolean value) {
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
@@ -119,7 +119,7 @@ public class RecordBuilderImpl extends AbstractRecordAccessorImpl implements Rec
       return withNullField(name);
     }
 
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
@@ -130,7 +130,7 @@ public class RecordBuilderImpl extends AbstractRecordAccessorImpl implements Rec
       return withNullField(name);
     }
 
-    fieldValues.put(name, new JsonPrimitive(value));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(value)));
     return this;
   }
 
@@ -148,12 +148,23 @@ public class RecordBuilderImpl extends AbstractRecordAccessorImpl implements Rec
 
     ReferenceIdImpl referenceIdImpl = (ReferenceIdImpl) value;
 
-    fieldValues.put(name, new JsonPrimitive(referenceIdImpl.toApiString()));
+    fieldValues.put(name, new FieldValue(new JsonPrimitive(referenceIdImpl.toApiString())));
+    return this;
+  }
+
+  @Nonnull
+  @Override
+  public RecordBuilder withField(String name, @Nullable ByteBuffer value) {
+    if (value == null) {
+      return withNullField(name);
+    }
+
+    fieldValues.put(name, new FieldValue(value));
     return this;
   }
 
   @Override
-  protected TreeMap<String, JsonElement> getFieldValues() {
+  protected TreeMap<String, FieldValue> getFieldValues() {
     return fieldValues;
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordImpl.java
@@ -6,22 +6,21 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.google.gson.JsonElement;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import java.util.Map;
 import java.util.TreeMap;
 
 public class RecordImpl extends AbstractRecordAccessorImpl implements Record {
-  private final TreeMap<String, JsonElement> fieldValues =
+  private final TreeMap<String, FieldValue> fieldValues =
       new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
-  public <A extends JsonElement> RecordImpl(String type, Map<String, A> fieldValues) {
+  public RecordImpl(String type, Map<String, FieldValue> fieldValues) {
     super(type);
     this.fieldValues.putAll(fieldValues);
   }
 
   @Override
-  public TreeMap<String, JsonElement> getFieldValues() {
+  public TreeMap<String, FieldValue> getFieldValues() {
     return fieldValues;
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordQueryResultImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordQueryResultImpl.java
@@ -6,49 +6,45 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryRecordResult;
 import com.salesforce.functions.jvm.sdk.data.RecordQueryResult;
 import com.salesforce.functions.jvm.sdk.data.RecordWithSubQueryResults;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.*;
 import javax.annotation.Nonnull;
 
 public class RecordQueryResultImpl implements RecordQueryResult {
-  private final QueryRecordResult queryRecordResult;
+  private final boolean isDone;
+  private final long totalSize;
+  private final Optional<String> nextRecordsPath;
+  private final List<RecordWithSubQueryResultsImpl> records;
 
-  public RecordQueryResultImpl(QueryRecordResult queryRecordResult) {
-    this.queryRecordResult = queryRecordResult;
+  public RecordQueryResultImpl(
+      boolean isDone,
+      long totalSize,
+      Optional<String> nextRecordsPath,
+      List<RecordWithSubQueryResultsImpl> records) {
+    this.isDone = isDone;
+    this.totalSize = totalSize;
+    this.nextRecordsPath = nextRecordsPath;
+    this.records = records;
   }
 
   @Override
   public boolean isDone() {
-    return queryRecordResult.isDone();
+    return isDone;
   }
 
   @Override
   public long getTotalSize() {
-    return queryRecordResult.getTotalSize();
+    return totalSize;
   }
 
   @Nonnull
   @Override
   public List<RecordWithSubQueryResults> getRecords() {
-    return queryRecordResult.getRecords().stream()
-        .map(
-            record ->
-                new RecordWithSubQueryResultsImpl(
-                    record.getAttributes().get("type").getAsString(),
-                    record.getValues(),
-                    record.getSubQueryResults()))
-        .collect(Collectors.toList());
+    return Collections.unmodifiableList(records);
   }
 
   public Optional<String> getNextRecordsPath() {
-    return queryRecordResult.getNextRecordsPath();
-  }
-
-  public QueryRecordResult getQueryRecordResult() {
-    return queryRecordResult;
+    return nextRecordsPath;
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordWithSubQueryResultsImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordWithSubQueryResultsImpl.java
@@ -6,8 +6,6 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.google.gson.JsonElement;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryRecordResult;
 import com.salesforce.functions.jvm.sdk.data.RecordQueryResult;
 import com.salesforce.functions.jvm.sdk.data.RecordWithSubQueryResults;
 import java.util.Map;
@@ -15,10 +13,13 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 
 public class RecordWithSubQueryResultsImpl extends RecordImpl implements RecordWithSubQueryResults {
-  private final Map<String, QueryRecordResult> subQueryResults;
+  private final Map<String, RecordQueryResultImpl> subQueryResults;
 
-  public <A extends JsonElement> RecordWithSubQueryResultsImpl(
-      String type, Map<String, A> fieldValues, Map<String, QueryRecordResult> subQueryResults) {
+  public RecordWithSubQueryResultsImpl(
+      String type,
+      Map<String, FieldValue> fieldValues,
+      Map<String, RecordQueryResultImpl> subQueryResults) {
+
     super(type, fieldValues);
     this.subQueryResults = subQueryResults;
   }
@@ -26,6 +27,6 @@ public class RecordWithSubQueryResultsImpl extends RecordImpl implements RecordW
   @Nonnull
   @Override
   public Optional<RecordQueryResult> getSubQueryResult(String objectName) {
-    return Optional.ofNullable(subQueryResults.get(objectName)).map(RecordQueryResultImpl::new);
+    return Optional.ofNullable(subQueryResults.get(objectName));
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImplTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImplTest.java
@@ -101,6 +101,7 @@ public class DataApiImplTest {
 
   @Test
   public void testQueryWithSubQueryResults() throws DataApiException {
+
     RecordQueryResult result =
         dataApi.query(
             "SELECT Account.Name, (SELECT Contact.FirstName, Contact.LastName FROM Account.Contacts) FROM Account LIMIT 5");


### PR DESCRIPTION
This is the second PR for supporting the upcoming SDK version `1.1`. The SDK version `1.1` (see [SDK repo](https://github.com/forcedotcom/sf-fx-sdk-java/tree/1.1)) is not final yet, this PR targets the SNAPSHOT version from 7/29. Refer to the linked SDK branch for customer surfacing changes.

It implements support for both reading and writing binary data.

Additional code will be added in the [sdk-1.1 branch](https://github.com/forcedotcom/sf-fx-runtime-java/tree/sdk-1.1) that implements new features and eventually targets the released `1.1` version of the SDK instead of the SNAPSHOT version.

Closes GUS-W-11514685