### PR TITLE
Use org domain URL when making API requests

### DIFF
--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
@@ -45,8 +45,8 @@ public class DataApiImpl implements DataApi {
 
   private final RestApi restApi;
 
-  public DataApiImpl(URI salesforceBaseUrl, String apiVersion, String accessToken) {
-    this.restApi = new RestApi(salesforceBaseUrl, apiVersion, accessToken);
+  public DataApiImpl(URI orgDomainUrl, String apiVersion, String accessToken) {
+    this.restApi = new RestApi(orgDomainUrl, apiVersion, accessToken);
   }
 
   @Override
@@ -135,7 +135,7 @@ public class DataApiImpl implements DataApi {
 
     CompositeGraphRestApiRequest<ModifyRecordResult> request =
         new CompositeGraphRestApiRequest<>(
-            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), impl.getSubrequests());
+            restApi.getOrgDomainUrl(), restApi.getApiVersion(), impl.getSubrequests());
 
     Map<String, ModifyRecordResult> result = executeRequest(request);
 

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
@@ -45,8 +45,8 @@ public class DataApiImpl implements DataApi {
 
   private final RestApi restApi;
 
-  public DataApiImpl(URI salesforceBaseUrl, String apiVersion, String accessToken) {
-    this.restApi = new RestApi(salesforceBaseUrl, apiVersion, accessToken);
+  public DataApiImpl(URI orgDomainUrl, String apiVersion, String accessToken) {
+    this.restApi = new RestApi(orgDomainUrl, apiVersion, accessToken);
   }
 
   @Override
@@ -126,7 +126,7 @@ public class DataApiImpl implements DataApi {
 
     CompositeGraphRestApiRequest<ModifyRecordResult> request =
         new CompositeGraphRestApiRequest<>(
-            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), impl.getSubrequests());
+            restApi.getOrgDomainUrl(), restApi.getApiVersion(), impl.getSubrequests());
 
     Map<String, ModifyRecordResult> result = executeRequest(request);
 

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/OrgImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/OrgImpl.java
@@ -26,7 +26,8 @@ public class OrgImpl implements Org {
     this.apiVersion = apiVersion;
     this.salesforceContext = salesforceContext;
     this.dataApi =
-        new DataApiImpl(this.getBaseUrl(), this.getApiVersion(), functionContext.getAccessToken());
+        new DataApiImpl(
+            this.getDomainUrl(), this.getApiVersion(), functionContext.getAccessToken());
     this.user = new UserImpl(salesforceContext);
   }
 

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApi.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApi.java
@@ -31,21 +31,21 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 
 public final class RestApi {
-  private final URI salesforceBaseUrl;
+  private final URI orgDomainUrl;
   private final String apiVersion;
   private final String accessToken;
   private final String clientVersion;
   private final Gson gson = new Gson();
 
-  public RestApi(URI salesforceBaseUrl, String apiVersion, String accessToken) {
-    this.salesforceBaseUrl = salesforceBaseUrl;
+  public RestApi(URI orgDomainUrl, String apiVersion, String accessToken) {
+    this.orgDomainUrl = orgDomainUrl;
     this.apiVersion = apiVersion;
     this.accessToken = accessToken;
     this.clientVersion = readVersionStringFromProperties().orElse("?.?.?-unknown");
   }
 
-  public URI getSalesforceBaseUrl() {
-    return salesforceBaseUrl;
+  public URI getOrgDomainUrl() {
+    return orgDomainUrl;
   }
 
   public String getApiVersion() {
@@ -60,7 +60,7 @@ public final class RestApi {
       throws RestApiErrorsException, RestApiException, IOException {
     URI uri;
     try {
-      uri = apiRequest.createUri(salesforceBaseUrl, apiVersion);
+      uri = apiRequest.createUri(orgDomainUrl, apiVersion);
     } catch (URISyntaxException e) {
       throw new RuntimeException("Unexpected URISyntaxException!", e);
     }
@@ -96,7 +96,7 @@ public final class RestApi {
   }
 
   public ByteBuffer downloadFile(String relativeUrl) throws URISyntaxException, IOException {
-    URI uri = new URIBuilder(this.salesforceBaseUrl).setPath(relativeUrl).build();
+    URI uri = new URIBuilder(this.orgDomainUrl).setPath(relativeUrl).build();
 
     HttpUriRequest request = createBaseHttpRequest(HttpMethod.GET, uri, Optional.empty());
 

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
@@ -44,7 +44,7 @@ public class RestApiCompositeTest {
 
     CompositeGraphRestApiRequest<ModifyRecordResult> request =
         new CompositeGraphRestApiRequest<>(
-            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), subrequests);
+            restApi.getOrgDomainUrl(), restApi.getApiVersion(), subrequests);
     Map<String, ModifyRecordResult> result = restApi.execute(request);
 
     assertThat(
@@ -63,7 +63,7 @@ public class RestApiCompositeTest {
 
     CompositeGraphRestApiRequest<ModifyRecordResult> request =
         new CompositeGraphRestApiRequest<>(
-            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), subrequests);
+            restApi.getOrgDomainUrl(), restApi.getApiVersion(), subrequests);
 
     try {
       restApi.execute(request);
@@ -93,7 +93,7 @@ public class RestApiCompositeTest {
 
     CompositeGraphRestApiRequest<ModifyRecordResult> request =
         new CompositeGraphRestApiRequest<>(
-            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), subrequests);
+            restApi.getOrgDomainUrl(), restApi.getApiVersion(), subrequests);
     Map<String, ModifyRecordResult> result = restApi.execute(request);
 
     assertThat(
@@ -127,7 +127,7 @@ public class RestApiCompositeTest {
 
     CompositeGraphRestApiRequest<ModifyRecordResult> request =
         new CompositeGraphRestApiRequest<>(
-            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), subrequests);
+            restApi.getOrgDomainUrl(), restApi.getApiVersion(), subrequests);
     Map<String, ModifyRecordResult> result = restApi.execute(request);
 
     assertThat(
@@ -155,7 +155,7 @@ public class RestApiCompositeTest {
 
     CompositeGraphRestApiRequest<ModifyRecordResult> request =
         new CompositeGraphRestApiRequest<>(
-            restApi.getSalesforceBaseUrl(), restApi.getApiVersion(), subrequests);
+            restApi.getOrgDomainUrl(), restApi.getApiVersion(), subrequests);
     Map<String, ModifyRecordResult> result = restApi.execute(request);
 
     assertThat(


### PR DESCRIPTION
Use org domain URL when making API requests instead of Salesforce base URL. When using Salesforce Sites, the base URL can in some cases point to the incorrect API endpoint.

Closes GUS-W-11819237