### PR TITLE
Use released SDK 1.1 instead of SNAPSHOT

### DIFF
--- a/integration-test/openjdk-11/sdk-1.1.0/pom.xml
+++ b/integration-test/openjdk-11/sdk-1.1.0/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.salesforce.functions</groupId>
       <artifactId>sf-fx-sdk-java</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/integration-test/openjdk-8/sdk-1.1.0/pom.xml
+++ b/integration-test/openjdk-8/sdk-1.1.0/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.salesforce.functions</groupId>
       <artifactId>sf-fx-sdk-java</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
@@ -449,7 +449,7 @@ public class SalesforceFunctionsProjectFunctionsScanner
 
     Map<String, String> mapping = new HashMap<>();
     mapping.put("1.0.0", "sdk-impl-v1.jar");
-    mapping.put("1.1.0-SNAPSHOT", "sdk-impl-v1.1.jar");
+    mapping.put("1.1.0", "sdk-impl-v1.1.jar");
 
     return Optional.ofNullable(properties.getProperty("version"))
         .flatMap((version) -> Optional.ofNullable(mapping.get(version)));

--- a/sf-fx-runtime-java-sdk-impl-v1.1/pom.xml
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.salesforce.functions</groupId>
       <artifactId>sf-fx-sdk-java</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
SDK 1.1 has been released, so we need to refer to the released version instead of the SNAPSHOT version.