### PR TITLE
Fix parsing of query with nested object

### DIFF
--- a/sf-fx-runtime-java-sdk-impl-v1.1/pom.xml
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.salesforce.functions</groupId>
       <artifactId>sf-fx-sdk-java</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/AbstractRecordAccessorImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/AbstractRecordAccessorImpl.java
@@ -8,6 +8,7 @@ package com.salesforce.functions.jvm.runtime.sdk;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
+import com.salesforce.functions.jvm.sdk.data.Record;
 import com.salesforce.functions.jvm.sdk.data.RecordAccessor;
 import com.salesforce.functions.jvm.sdk.data.error.FieldConversionException;
 import java.math.BigDecimal;
@@ -136,6 +137,20 @@ public abstract class AbstractRecordAccessorImpl implements RecordAccessor {
     } else {
       return fieldValue.flatMap(value -> Optional.ofNullable(value.getBinaryData()));
     }
+  }
+
+  @Nonnull
+  @Override
+  public Optional<Record> getRecordField(String name) {
+    Optional<FieldValue> fieldValue =
+        Optional.ofNullable(getFieldValues().get(name)).filter(FieldValue::isRecordData);
+
+    if (fieldValue.isPresent() && !fieldValue.get().isRecordData()) {
+      throw new FieldConversionException(
+          String.format("Field %s cannot be converted to Record.", name));
+    }
+
+    return fieldValue.flatMap(value -> Optional.ofNullable(value.getRecordData()));
   }
 
   @Nonnull

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
@@ -6,7 +6,6 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.google.gson.JsonElement;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.CompositeGraphRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.CreateRecordRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.DeleteRecordRestApiRequest;
@@ -169,7 +168,7 @@ public class DataApiImpl implements DataApi {
                     new IllegalArgumentException(
                         "Given Record does not have an Id field and therefore cannot be updated."));
 
-    Map<String, JsonElement> fieldValues = BinaryFieldUtil.convert(recordImpl.getFieldValues());
+    Map<String, Object> fieldValues = BinaryFieldUtil.convert(recordImpl.getFieldValues());
     fieldValues.remove("id");
 
     return new UpdateRecordRestApiRequest(id, recordImpl.getType(), fieldValues);

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/FieldValue.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/FieldValue.java
@@ -7,21 +7,31 @@
 package com.salesforce.functions.jvm.runtime.sdk;
 
 import com.google.gson.JsonElement;
+import com.salesforce.functions.jvm.sdk.data.Record;
 import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
 
 public class FieldValue {
   private final JsonElement jsonData;
   private final ByteBuffer binaryData;
+  private final Record recordData;
 
   public FieldValue(@Nonnull JsonElement jsonData) {
     this.jsonData = jsonData;
     this.binaryData = null;
+    this.recordData = null;
   }
 
   public FieldValue(@Nonnull ByteBuffer binaryData) {
     this.binaryData = binaryData;
     this.jsonData = null;
+    this.recordData = null;
+  }
+
+  public FieldValue(@Nonnull Record recordData) {
+    this.recordData = recordData;
+    this.jsonData = null;
+    this.binaryData = null;
   }
 
   public boolean isBinaryData() {
@@ -40,8 +50,23 @@ public class FieldValue {
     return binaryData;
   }
 
+  public Record getRecordData() {
+    return this.recordData;
+  }
+
+  public boolean isRecordData() {
+    return this.recordData != null;
+  }
+
   @Override
   public String toString() {
-    return "FieldValue{" + "jsonData=" + jsonData + ", binaryData=" + binaryData + '}';
+    return "FieldValue{"
+        + "jsonData="
+        + jsonData
+        + ", binaryData="
+        + binaryData
+        + ", recordData="
+        + recordData
+        + '}';
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImplTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImplTest.java
@@ -186,6 +186,20 @@ public class DataApiImplTest {
   }
 
   @Test
+  public void testQueryWithAssociatedRecordResults() throws DataApiException {
+    RecordQueryResult result = dataApi.query("SELECT Name, Owner.Name from Account LIMIT 1");
+    assertThat(result.isDone(), is(true));
+    assertThat(result.getTotalSize(), is(1L));
+
+    Record record = result.getRecords().get(0);
+    assertThat(record.getRecordField("Owner").get(), isA(Record.class));
+
+    Record nestedRecord = record.getRecordField("Owner").get();
+    assertThat(nestedRecord.getType(), is("User"));
+    assertThat(nestedRecord.getStringField("Name").get(), is("Guy Smiley"));
+  }
+
+  @Test
   public void testCreate() throws DataApiException {
     RecordModificationResult result =
         dataApi.create(

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/test/resources/mappings/query-with-associated-data.json
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/test/resources/mappings/query-with-associated-data.json
@@ -1,0 +1,32 @@
+{
+  "id" : "fb30aeaf-08a7-4cbc-b4c0-50fc034c1409",
+  "name" : "services_data_v530_query",
+  "request" : {
+    "urlPath" : "/services/data/v53.0/query",
+    "method" : "GET",
+    "queryParameters": {
+      "q": {
+        "equalTo": "SELECT Name, Owner.Name from Account LIMIT 1"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"totalSize\":1,\"done\":true,\"records\":[{\"attributes\":{\"type\":\"Account\",\"url\":\"/services/data/v53.0/sobjects/Account/001B000001PUvQUIA1\"},\"Name\":\"TestAccount5\",\"Owner\":{\"attributes\":{\"type\":\"User\",\"url\":\"/services/data/v53.0/sobjects/User/005B0000008UC2PIAW\"},\"Name\":\"Guy Smiley\"}}]}",
+    "headers" : {
+      "Date" : "Fri, 02 Dec 2022 18:02:55 GMT",
+      "Set-Cookie" : [ "CookieConsentPolicy=0:1; path=/; expires=Sat, 02-Dec-2023 18:02:55 GMT; Max-Age=31536000", "LSKey-c$CookieConsentPolicy=0:1; path=/; expires=Sat, 02-Dec-2023 18:02:55 GMT; Max-Age=31536000", "BrowserId=jA2SIXJrEe2HE63eO1gD5Q; domain=.salesforce.com; path=/; expires=Sat, 02-Dec-2023 18:02:55 GMT; Max-Age=31536000" ],
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Sforce-Limit-Info" : "api-usage=11/100000",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "fb30aeaf-08a7-4cbc-b4c0-50fc034c1409",
+  "persistent" : true,
+  "insertionIndex" : 3
+}

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/AbstractRecordAccessorImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/AbstractRecordAccessorImpl.java
@@ -24,7 +24,7 @@ public abstract class AbstractRecordAccessorImpl implements RecordAccessor {
     this.type = type;
   }
 
-  protected abstract TreeMap<String, JsonElement> getFieldValues();
+  protected abstract TreeMap<String, Object> getFieldValues();
 
   @Nonnull
   @Override
@@ -46,6 +46,8 @@ public abstract class AbstractRecordAccessorImpl implements RecordAccessor {
   @Override
   public boolean isNullField(String name) {
     return Optional.ofNullable(getFieldValues().get(name))
+        .filter(e -> e instanceof JsonElement)
+        .map(e -> (JsonElement) e)
         .map(JsonElement::isJsonNull)
         .orElse(false);
   }
@@ -113,6 +115,8 @@ public abstract class AbstractRecordAccessorImpl implements RecordAccessor {
   @Nonnull
   private <T> Optional<T> getFieldValue(String fieldName, Function<JsonPrimitive, T> f) {
     return Optional.ofNullable(getFieldValues().get(fieldName))
+        .filter(e -> e instanceof JsonElement)
+        .map(e -> (JsonElement) e)
         .filter(JsonElement::isJsonPrimitive)
         .map(jsonElement -> f.apply(jsonElement.getAsJsonPrimitive()));
   }

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
@@ -6,7 +6,6 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.google.gson.JsonElement;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.CompositeGraphRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.CreateRecordRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.DeleteRecordRestApiRequest;
@@ -160,7 +159,7 @@ public class DataApiImpl implements DataApi {
                     new IllegalArgumentException(
                         "Given Record does not have an Id field and therefore cannot be updated."));
 
-    Map<String, JsonElement> fieldValues = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, Object> fieldValues = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     fieldValues.putAll(recordImpl.getFieldValues());
     fieldValues.remove("id");
 

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordBuilderImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordBuilderImpl.java
@@ -6,7 +6,6 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
 import com.salesforce.functions.jvm.sdk.data.Record;
@@ -20,14 +19,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class RecordBuilderImpl extends AbstractRecordAccessorImpl implements RecordBuilder {
-  private final TreeMap<String, JsonElement> fieldValues =
-      new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+  private final TreeMap<String, Object> fieldValues = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
   public RecordBuilderImpl(String type) {
     super(type);
   }
 
-  public RecordBuilderImpl(String type, Map<String, JsonElement> fieldValues) {
+  public RecordBuilderImpl(String type, Map<String, Object> fieldValues) {
     super(type);
     this.fieldValues.putAll(fieldValues);
   }
@@ -153,7 +151,7 @@ public class RecordBuilderImpl extends AbstractRecordAccessorImpl implements Rec
   }
 
   @Override
-  protected TreeMap<String, JsonElement> getFieldValues() {
+  protected TreeMap<String, Object> getFieldValues() {
     return fieldValues;
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/RecordImpl.java
@@ -6,22 +6,20 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.google.gson.JsonElement;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import java.util.Map;
 import java.util.TreeMap;
 
 public class RecordImpl extends AbstractRecordAccessorImpl implements Record {
-  private final TreeMap<String, JsonElement> fieldValues =
-      new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+  private final TreeMap<String, Object> fieldValues = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
-  public <A extends JsonElement> RecordImpl(String type, Map<String, A> fieldValues) {
+  public RecordImpl(String type, Map<String, Object> fieldValues) {
     super(type);
     this.fieldValues.putAll(fieldValues);
   }
 
   @Override
-  public TreeMap<String, JsonElement> getFieldValues() {
+  public TreeMap<String, Object> getFieldValues() {
     return fieldValues;
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/RecordImplTest.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/RecordImplTest.java
@@ -28,7 +28,7 @@ public class RecordImplTest {
 
   @Before
   public void setUp() {
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put(NUMBER_MAX_BYTE_KEY, new JsonPrimitive(Byte.MAX_VALUE));
     values.put(NUMBER_MAX_SHORT_KEY, new JsonPrimitive(Short.MAX_VALUE));
     values.put(NUMBER_MAX_INT_KEY, new JsonPrimitive(Integer.MAX_VALUE));

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/AbstractQueryRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/AbstractQueryRestApiRequest.java
@@ -43,35 +43,42 @@ public abstract class AbstractQueryRestApiRequest implements RestApiRequest<Quer
     }
 
     for (JsonElement jsonElement : body.get("records").getAsJsonArray()) {
-      final JsonObject jsonObject = jsonElement.getAsJsonObject();
-
-      final JsonObject attributesObject = jsonObject.get("attributes").getAsJsonObject();
-      final Map<String, JsonPrimitive> attributes =
-          gson.fromJson(attributesObject, new TypeToken<Map<String, JsonPrimitive>>() {}.getType());
-
-      final Map<String, JsonPrimitive> values = new HashMap<>();
-      final Map<String, QueryRecordResult> subQueryResults = new HashMap<>();
-
-      for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
-        if (entry.getKey().equals("attributes")) {
-          continue;
-        }
-
-        if (entry.getValue().isJsonPrimitive()) {
-          values.put(entry.getKey(), entry.getValue().getAsJsonPrimitive());
-        } else if (entry.getValue().isJsonObject()) {
-          subQueryResults.put(entry.getKey(), parseQueryResult(entry.getValue().getAsJsonObject()));
-        } else {
-          // We don't throw an exception if the value is null, but it will not be added.
-          if (!entry.getValue().isJsonNull()) {
-            throw new RuntimeException("Unexpected value in record response: " + entry.getValue());
-          }
-        }
-      }
-
-      records.add(new Record(attributes, values, subQueryResults));
+      records.add(parseQueryRecord(jsonElement.getAsJsonObject()));
     }
 
     return new QueryRecordResult(totalSize, done, records, nextRecordsPath);
+  }
+
+  private Record parseQueryRecord(JsonObject data) {
+    final JsonObject attributesObject = data.get("attributes").getAsJsonObject();
+    final Map<String, JsonPrimitive> attributes =
+        gson.fromJson(attributesObject, new TypeToken<Map<String, JsonPrimitive>>() {}.getType());
+
+    final Map<String, Object> values = new HashMap<>();
+    final Map<String, QueryRecordResult> subQueryResults = new HashMap<>();
+
+    for (Map.Entry<String, JsonElement> entry : data.entrySet()) {
+      if (entry.getKey().equals("attributes")) {
+        continue;
+      }
+
+      if (entry.getValue().isJsonPrimitive()) {
+        values.put(entry.getKey(), entry.getValue().getAsJsonPrimitive());
+      } else if (entry.getValue().isJsonObject()) {
+        JsonObject nestedJsonObject = entry.getValue().getAsJsonObject();
+        if (nestedJsonObject.has("attributes")) {
+          values.put(entry.getKey(), parseQueryRecord(nestedJsonObject));
+        } else {
+          subQueryResults.put(entry.getKey(), parseQueryResult(nestedJsonObject));
+        }
+      } else {
+        // We don't throw an exception if the value is null, but it will not be added.
+        if (!entry.getValue().isJsonNull()) {
+          throw new RuntimeException("Unexpected value in record response: " + entry.getValue());
+        }
+      }
+    }
+
+    return new Record(attributes, values, subQueryResults);
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
@@ -16,9 +16,9 @@ import org.apache.http.client.utils.URIBuilder;
 
 public class CreateRecordRestApiRequest implements RestApiRequest<ModifyRecordResult> {
   private final String type;
-  private final Map<String, JsonElement> values;
+  private final Map<String, Object> values;
 
-  public CreateRecordRestApiRequest(String type, Map<String, JsonElement> values) {
+  public CreateRecordRestApiRequest(String type, Map<String, Object> values) {
     this.type = type;
     this.values = values;
   }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/Record.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/Record.java
@@ -14,12 +14,12 @@ import javax.annotation.Nonnull;
 
 public final class Record {
   private final Map<String, JsonPrimitive> attributes;
-  private final Map<String, JsonPrimitive> values;
+  private final Map<String, Object> values;
   private final Map<String, QueryRecordResult> subQueryResults;
 
   public Record(
       Map<String, JsonPrimitive> attributes,
-      Map<String, JsonPrimitive> values,
+      Map<String, Object> values,
       Map<String, QueryRecordResult> subQueryResults) {
     this.attributes = attributes;
     this.values = values;
@@ -32,7 +32,7 @@ public final class Record {
   }
 
   @Nonnull
-  public Map<String, JsonPrimitive> getValues() {
+  public Map<String, Object> getValues() {
     return Collections.unmodifiableMap(values);
   }
 

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
@@ -18,9 +18,9 @@ import org.apache.http.client.utils.URIBuilder;
 public class UpdateRecordRestApiRequest implements RestApiRequest<ModifyRecordResult> {
   private final String id;
   private final String type;
-  private final Map<String, JsonElement> values;
+  private final Map<String, Object> values;
 
-  public UpdateRecordRestApiRequest(String id, String type, Map<String, JsonElement> values) {
+  public UpdateRecordRestApiRequest(String id, String type, Map<String, Object> values) {
     this.id = id;
     this.type = type;
     this.values = new HashMap<>(values);

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResultTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordResultTest.java
@@ -7,6 +7,7 @@
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
 import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.jsonPrimitiveMap;
+import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.map;
 
 import java.util.Collections;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -22,7 +23,7 @@ public class QueryRecordResultTest {
                 new RecordBuilder.JsonPrimitiveTuple("type", "Account"),
                 new RecordBuilder.JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/001B000001LwihuIAB")),
-            jsonPrimitiveMap(new RecordBuilder.JsonPrimitiveTuple("Name", "Acme")),
+            map(new RecordBuilder.JsonPrimitiveTuple("Name", "Acme")),
             Collections.emptyMap());
 
     Record blue =
@@ -31,8 +32,7 @@ public class QueryRecordResultTest {
                 new RecordBuilder.JsonPrimitiveTuple("type", "Account"),
                 new RecordBuilder.JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/001B000001LnobCIAR")),
-            jsonPrimitiveMap(
-                new RecordBuilder.JsonPrimitiveTuple("Name", "Sample Account for Entitlements")),
+            map(new RecordBuilder.JsonPrimitiveTuple("Name", "Sample Account for Entitlements")),
             Collections.emptyMap());
 
     EqualsVerifier.forClass(QueryRecordResult.class)

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordBuilder.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordBuilder.java
@@ -20,6 +20,15 @@ public final class RecordBuilder {
     return result;
   }
 
+  public static Map<String, Object> map(JsonPrimitiveTuple... data) {
+    HashMap<String, Object> result = new HashMap<>();
+    for (JsonPrimitiveTuple tuple : data) {
+      result.put(tuple.getKey(), tuple.getValue());
+    }
+
+    return result;
+  }
+
   public static Map<String, QueryRecordResult> queryResultMap(QueryResultTuple... data) {
     HashMap<String, QueryRecordResult> result = new HashMap<>();
     for (QueryResultTuple tuple : data) {

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RecordTest.java
@@ -7,6 +7,7 @@
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
 import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.jsonPrimitiveMap;
+import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -24,7 +25,7 @@ public class RecordTest {
   public void testValuesAndAttributesAreUnmodified() {
     Map<String, JsonPrimitive> attributes = new HashMap<>();
 
-    Map<String, JsonPrimitive> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("foo", new JsonPrimitive("bar"));
     values.put("bar", new JsonPrimitive("baz"));
 
@@ -44,7 +45,7 @@ public class RecordTest {
                 new RecordBuilder.JsonPrimitiveTuple("type", "Account"),
                 new RecordBuilder.JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/001B000001LwihuIAB")),
-            jsonPrimitiveMap(new RecordBuilder.JsonPrimitiveTuple("Name", "Acme")),
+            map(new RecordBuilder.JsonPrimitiveTuple("Name", "Acme")),
             Collections.emptyMap());
 
     Record blue =
@@ -53,8 +54,7 @@ public class RecordTest {
                 new RecordBuilder.JsonPrimitiveTuple("type", "Account"),
                 new RecordBuilder.JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/001B000001LnobCIAR")),
-            jsonPrimitiveMap(
-                new RecordBuilder.JsonPrimitiveTuple("Name", "Sample Account for Entitlements")),
+            map(new RecordBuilder.JsonPrimitiveTuple("Name", "Sample Account for Entitlements")),
             Collections.emptyMap());
 
     EqualsVerifier.forClass(Record.class).withPrefabValues(Record.class, red, blue).verify();

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import java.io.IOException;
 import java.net.URI;
@@ -37,7 +36,7 @@ public class RestApiCompositeTest {
   public void compositeSingleCreate() throws RestApiErrorsException, IOException, RestApiException {
     Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
 
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Star Wars Episode IV - A New Hope"));
     values.put("Rating__c", new JsonPrimitive("Excellent"));
     subrequests.put("insert-anh", new CreateRecordRestApiRequest("Movie__c", values));
@@ -56,7 +55,7 @@ public class RestApiCompositeTest {
   public void compositeSingleCreateWithError() throws IOException, RestApiException {
     Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
 
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Star Wars Episode IV - A New Hope"));
     values.put("Rating__c", new JsonPrimitive("Amazing"));
     subrequests.put("insert-anh", new CreateRecordRestApiRequest("Movie__c", values));
@@ -86,7 +85,7 @@ public class RestApiCompositeTest {
   public void compositeSingleUpdate() throws RestApiErrorsException, IOException, RestApiException {
     Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
 
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
     subrequests.put(
         "referenceId0", new UpdateRecordRestApiRequest("a01B0000009gSrFIAU", "Movie__c", values));
@@ -105,22 +104,22 @@ public class RestApiCompositeTest {
   public void compositeCreateTree() throws RestApiErrorsException, IOException, RestApiException {
     Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new LinkedHashMap<>();
 
-    Map<String, JsonElement> valuesFranchise = new HashMap<>();
+    Map<String, Object> valuesFranchise = new HashMap<>();
     valuesFranchise.put("Name", new JsonPrimitive("Star Wars"));
     subrequests.put(
         "referenceId0", new CreateRecordRestApiRequest("Franchise__c", valuesFranchise));
 
-    Map<String, JsonElement> valuesEp1 = new HashMap<>();
+    Map<String, Object> valuesEp1 = new HashMap<>();
     valuesEp1.put("Name", new JsonPrimitive("Star Wars Episode I - A Phantom Menace"));
     valuesEp1.put("Franchise__c", new JsonPrimitive("@{referenceId0.id}"));
     subrequests.put("referenceId1", new CreateRecordRestApiRequest("Movie__c", valuesEp1));
 
-    Map<String, JsonElement> valuesEp2 = new HashMap<>();
+    Map<String, Object> valuesEp2 = new HashMap<>();
     valuesEp2.put("Name", new JsonPrimitive("Star Wars Episode II - Attack Of The Clones"));
     valuesEp2.put("Franchise__c", new JsonPrimitive("@{referenceId0.id}"));
     subrequests.put("referenceId2", new CreateRecordRestApiRequest("Movie__c", valuesEp2));
 
-    Map<String, JsonElement> valuesEp3 = new HashMap<>();
+    Map<String, Object> valuesEp3 = new HashMap<>();
     valuesEp3.put("Name", new JsonPrimitive("Star Wars Episode III - Revenge Of The Sith"));
     valuesEp3.put("Franchise__c", new JsonPrimitive("@{referenceId0.id}"));
     subrequests.put("referenceId3", new CreateRecordRestApiRequest("Movie__c", valuesEp3));

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import java.io.IOException;
 import java.net.URI;
@@ -34,7 +33,7 @@ public class RestApiCreateTest {
 
   @Test
   public void create() throws RestApiErrorsException, IOException, RestApiException {
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Star Wars Episode V: The Empire Strikes Back"));
     values.put("Rating__c", new JsonPrimitive("Excellent"));
 
@@ -45,7 +44,7 @@ public class RestApiCreateTest {
 
   @Test
   public void createWithInvalidPicklistValue() throws IOException, RestApiException {
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Star Wars Episode VIII: The Last Jedi"));
     values.put("Rating__c", new JsonPrimitive("Terrible"));
 
@@ -72,7 +71,7 @@ public class RestApiCreateTest {
 
   @Test
   public void createWithUnknownObjectType() throws IOException, RestApiException {
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Ace of Spades"));
 
     CreateRecordRestApiRequest request = new CreateRecordRestApiRequest("PlayingCard__c", values);
@@ -96,7 +95,7 @@ public class RestApiCreateTest {
 
   @Test
   public void createWithInvalidField() throws IOException, RestApiException {
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("FavoritePet__c", new JsonPrimitive("Dog"));
 
     CreateRecordRestApiRequest request = new CreateRecordRestApiRequest("Account", values);
@@ -122,7 +121,7 @@ public class RestApiCreateTest {
 
   @Test
   public void createWithRequiredFieldMissing() throws IOException, RestApiException {
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Falcon 9"));
 
     CreateRecordRestApiRequest request = new CreateRecordRestApiRequest("Spaceship__c", values);

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
@@ -6,8 +6,7 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
-import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.jsonPrimitiveMap;
-import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.queryResultMap;
+import static com.salesforce.functions.jvm.runtime.sdk.restapi.RecordBuilder.*;
 import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -124,7 +123,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/001B000001LntWlIAJ")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "An awesome test account")),
+            map(new JsonPrimitiveTuple("Name", "An awesome test account")),
             Collections.emptyMap()));
 
     expectedRecords.add(
@@ -133,7 +132,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/001B000001LwihtIAB")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "Global Media")),
+            map(new JsonPrimitiveTuple("Name", "Global Media")),
             Collections.emptyMap()));
 
     expectedRecords.add(
@@ -142,7 +141,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/001B000001LwihuIAB")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "Acme")),
+            map(new JsonPrimitiveTuple("Name", "Acme")),
             Collections.emptyMap()));
 
     expectedRecords.add(
@@ -151,7 +150,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/001B000001LwihvIAB")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "salesforce.com")),
+            map(new JsonPrimitiveTuple("Name", "salesforce.com")),
             Collections.emptyMap()));
 
     expectedRecords.add(
@@ -160,7 +159,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/001B000001LnobCIAR")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "Sample Account for Entitlements")),
+            map(new JsonPrimitiveTuple("Name", "Sample Account for Entitlements")),
             Collections.emptyMap()));
 
     assertThat(result.getRecords(), is(equalTo(expectedRecords)));
@@ -183,7 +182,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/0017Q00000EZlbyQAD")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "GenePoint")),
+            map(new JsonPrimitiveTuple("Name", "GenePoint")),
             queryResultMap(
                 new RecordBuilder.QueryResultTuple(
                     "Contacts",
@@ -197,7 +196,7 @@ public class RestApiQueryTest {
                                     new JsonPrimitiveTuple(
                                         "url",
                                         "/services/data/v53.0/sobjects/Contact/0037Q000007vKjpQAE")),
-                                jsonPrimitiveMap(
+                                map(
                                     new JsonPrimitiveTuple("FirstName", "Edna"),
                                     new JsonPrimitiveTuple("LastName", "Frank")),
                                 queryResultMap())),
@@ -209,7 +208,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/0017Q00000EZlbwQAD")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "United Oil & Gas, UK")),
+            map(new JsonPrimitiveTuple("Name", "United Oil & Gas, UK")),
             queryResultMap(
                 new RecordBuilder.QueryResultTuple(
                     "Contacts",
@@ -223,7 +222,7 @@ public class RestApiQueryTest {
                                     new JsonPrimitiveTuple(
                                         "url",
                                         "/services/data/v53.0/sobjects/Contact/0037Q000007vKjmQAE")),
-                                jsonPrimitiveMap(
+                                map(
                                     new JsonPrimitiveTuple("FirstName", "Ashley"),
                                     new JsonPrimitiveTuple("LastName", "James")),
                                 queryResultMap())),
@@ -235,7 +234,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/0017Q00000EZlbxQAD")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "United Oil & Gas, Singapore")),
+            map(new JsonPrimitiveTuple("Name", "United Oil & Gas, Singapore")),
             queryResultMap(
                 new RecordBuilder.QueryResultTuple(
                     "Contacts",
@@ -249,7 +248,7 @@ public class RestApiQueryTest {
                                     new JsonPrimitiveTuple(
                                         "url",
                                         "/services/data/v53.0/sobjects/Contact/0037Q000007vKjnQAE")),
-                                jsonPrimitiveMap(
+                                map(
                                     new JsonPrimitiveTuple("FirstName", "Tom"),
                                     new JsonPrimitiveTuple("LastName", "Ripley")),
                                 queryResultMap()),
@@ -259,7 +258,7 @@ public class RestApiQueryTest {
                                     new JsonPrimitiveTuple(
                                         "url",
                                         "/services/data/v53.0/sobjects/Contact/0037Q000007vKjoQAE")),
-                                jsonPrimitiveMap(
+                                map(
                                     new JsonPrimitiveTuple("FirstName", "Liz"),
                                     new JsonPrimitiveTuple("LastName", "D'Cruz")),
                                 queryResultMap())),
@@ -271,7 +270,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/0017Q00000EZlboQAD")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "Edge Communications")),
+            map(new JsonPrimitiveTuple("Name", "Edge Communications")),
             queryResultMap(
                 new RecordBuilder.QueryResultTuple(
                     "Contacts",
@@ -285,7 +284,7 @@ public class RestApiQueryTest {
                                     new JsonPrimitiveTuple(
                                         "url",
                                         "/services/data/v53.0/sobjects/Contact/0037Q000007vKjZQAU")),
-                                jsonPrimitiveMap(
+                                map(
                                     new JsonPrimitiveTuple("FirstName", "Rose"),
                                     new JsonPrimitiveTuple("LastName", "Gonzalez")),
                                 queryResultMap()),
@@ -295,7 +294,7 @@ public class RestApiQueryTest {
                                     new JsonPrimitiveTuple(
                                         "url",
                                         "/services/data/v53.0/sobjects/Contact/0037Q000007vKjaQAE")),
-                                jsonPrimitiveMap(
+                                map(
                                     new JsonPrimitiveTuple("FirstName", "Sean"),
                                     new JsonPrimitiveTuple("LastName", "Forbes")),
                                 queryResultMap())),
@@ -307,7 +306,7 @@ public class RestApiQueryTest {
                 new JsonPrimitiveTuple("type", "Account"),
                 new JsonPrimitiveTuple(
                     "url", "/services/data/v53.0/sobjects/Account/0017Q00000EZlbpQAD")),
-            jsonPrimitiveMap(new JsonPrimitiveTuple("Name", "Burlington Textiles Corp of America")),
+            map(new JsonPrimitiveTuple("Name", "Burlington Textiles Corp of America")),
             queryResultMap(
                 new RecordBuilder.QueryResultTuple(
                     "Contacts",
@@ -321,7 +320,7 @@ public class RestApiQueryTest {
                                     new JsonPrimitiveTuple(
                                         "url",
                                         "/services/data/v53.0/sobjects/Contact/0037Q000007vKjbQAE")),
-                                jsonPrimitiveMap(
+                                map(
                                     new JsonPrimitiveTuple("FirstName", "Jack"),
                                     new JsonPrimitiveTuple("LastName", "Rogers")),
                                 queryResultMap())),

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import java.io.IOException;
 import java.net.URI;
@@ -34,7 +33,7 @@ public class RestApiUpdateTest {
 
   @Test
   public void update() throws RestApiErrorsException, IOException, RestApiException {
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
 
     UpdateRecordRestApiRequest request =
@@ -46,7 +45,7 @@ public class RestApiUpdateTest {
 
   @Test
   public void updateWithMalformedId() throws IOException, RestApiException {
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
 
     UpdateRecordRestApiRequest request =
@@ -71,7 +70,7 @@ public class RestApiUpdateTest {
 
   @Test
   public void updateWithInvalidField() throws IOException, RestApiException {
-    Map<String, JsonElement> values = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
     values.put("Color__c", new JsonPrimitive("Red"));
 
     UpdateRecordRestApiRequest request =


### PR DESCRIPTION
This modifies the parsing routine of data api queries to correctly parse result sets that include nested `Record` data.  

Requires the following SDK change:
* https://github.com/forcedotcom/sf-fx-sdk-java/pull/106

[W-12157391](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001FgZMwYAN/view)