### PR TITLE
Add Bulk API requests to REST API module

### DIFF
--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
@@ -8,6 +8,8 @@ package com.salesforce.functions.jvm.runtime.sdk;
 
 import com.google.gson.JsonElement;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.*;
 import com.salesforce.functions.jvm.sdk.data.DataApi;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import com.salesforce.functions.jvm.sdk.data.RecordModificationResult;

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkBuilderImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkBuilderImpl.java
@@ -6,9 +6,9 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.salesforce.functions.jvm.runtime.sdk.restapi.DeleteRecordRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.JsonRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.DeleteRecordRestApiRequest;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import com.salesforce.functions.jvm.sdk.data.ReferenceId;
 import com.salesforce.functions.jvm.sdk.data.UnitOfWork;

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkImpl.java
@@ -6,8 +6,8 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.salesforce.functions.jvm.runtime.sdk.restapi.JsonRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
 import com.salesforce.functions.jvm.sdk.data.UnitOfWork;
 import java.util.Collections;
 import java.util.LinkedHashMap;

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
@@ -8,6 +8,8 @@ package com.salesforce.functions.jvm.runtime.sdk;
 
 import com.google.gson.JsonElement;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.*;
 import com.salesforce.functions.jvm.sdk.data.DataApi;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import com.salesforce.functions.jvm.sdk.data.RecordModificationResult;

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkBuilderImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkBuilderImpl.java
@@ -6,9 +6,9 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.salesforce.functions.jvm.runtime.sdk.restapi.DeleteRecordRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.JsonRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.DeleteRecordRestApiRequest;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import com.salesforce.functions.jvm.sdk.data.ReferenceId;
 import com.salesforce.functions.jvm.sdk.data.UnitOfWork;

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkImpl.java
@@ -6,8 +6,8 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
-import com.salesforce.functions.jvm.runtime.sdk.restapi.JsonRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
 import com.salesforce.functions.jvm.sdk.data.UnitOfWork;
 import java.util.Collections;
 import java.util.LinkedHashMap;

--- a/sf-fx-runtime-java-sdk-rest-api/pom.xml
+++ b/sf-fx-runtime-java-sdk-rest-api/pom.xml
@@ -22,6 +22,11 @@
       <version>4.5.13</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.9.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/HttpMethod.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/HttpMethod.java
@@ -10,5 +10,6 @@ public enum HttpMethod {
   GET,
   POST,
   PATCH,
-  DELETE
+  DELETE,
+  PUT,
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApi.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApi.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -83,7 +84,7 @@ public final class RestApi {
             response.getStatusLine().getStatusCode(), headers, apiRequest.parseBody(bodyBytes));
       } catch (BodyParsingException e) {
         throw new RestApiException(
-            "Could not parse API response!\n" + Arrays.toString(bodyBytes), e);
+            "Could not parse API response!\n" + new String(bodyBytes, StandardCharsets.UTF_8), e);
       }
     }
   }
@@ -114,6 +115,9 @@ public final class RestApi {
           break;
         case PATCH:
           httpEntityEnclosingRequest = new HttpPatch(uri);
+          break;
+        case PUT:
+          httpEntityEnclosingRequest = new HttpPut(uri);
           break;
         default:
           // Since we don't get exhaustive switch/cases (JEP 361, previews since Java 12+) we put

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkIngestJobInfo.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkIngestJobInfo.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+import com.google.gson.annotations.JsonAdapter;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+public final class BulkIngestJobInfo {
+  private final String id;
+  private final BulkIngestOperation operation;
+  private final String object;
+  private final String createdById;
+
+  @JsonAdapter(SalesforceDateTimeStringJsonAdapter.class)
+  private final Instant createdDate;
+
+  @JsonAdapter(SalesforceDateTimeStringJsonAdapter.class)
+  private final Instant systemModstamp;
+
+  private final BulkJobState state;
+  private final ContentType contentType;
+  private final String apiVersion;
+  private final LineEnding lineEnding;
+  private final ColumnDelimiter columnDelimiter;
+
+  private final long numberRecordsProcessed;
+  private final long numberRecordsFailed;
+  private final long retries;
+
+  @JsonAdapter(DurationJsonAdapter.class)
+  private final Duration totalProcessingTime;
+
+  @JsonAdapter(DurationJsonAdapter.class)
+  private final Duration apiActiveProcessingTime;
+
+  @JsonAdapter(DurationJsonAdapter.class)
+  private final Duration apexProcessingTime;
+
+  public BulkIngestJobInfo(
+      String id,
+      BulkIngestOperation operation,
+      String object,
+      String createdById,
+      Instant createdDate,
+      Instant systemModstamp,
+      BulkJobState state,
+      ContentType contentType,
+      String apiVersion,
+      LineEnding lineEnding,
+      ColumnDelimiter columnDelimiter,
+      long numberRecordsProcessed,
+      long numberRecordsFailed,
+      long retries,
+      Duration totalProcessingTime,
+      Duration apiActiveProcessingTime,
+      Duration apexProcessingTime) {
+    this.id = id;
+    this.operation = operation;
+    this.object = object;
+    this.createdById = createdById;
+    this.createdDate = createdDate;
+    this.systemModstamp = systemModstamp;
+    this.state = state;
+    this.contentType = contentType;
+    this.apiVersion = apiVersion;
+    this.lineEnding = lineEnding;
+    this.columnDelimiter = columnDelimiter;
+    this.numberRecordsProcessed = numberRecordsProcessed;
+    this.numberRecordsFailed = numberRecordsFailed;
+    this.retries = retries;
+    this.totalProcessingTime = totalProcessingTime;
+    this.apiActiveProcessingTime = apiActiveProcessingTime;
+    this.apexProcessingTime = apexProcessingTime;
+  }
+
+  @Override
+  public String toString() {
+    return "BulkIngestJobInfo{"
+        + "id='"
+        + id
+        + '\''
+        + ", operation="
+        + operation
+        + ", object='"
+        + object
+        + '\''
+        + ", createdById='"
+        + createdById
+        + '\''
+        + ", createdDate="
+        + createdDate
+        + ", systemModstamp="
+        + systemModstamp
+        + ", state="
+        + state
+        + ", contentType="
+        + contentType
+        + ", apiVersion='"
+        + apiVersion
+        + '\''
+        + ", lineEnding="
+        + lineEnding
+        + ", columnDelimiter="
+        + columnDelimiter
+        + ", numberRecordsProcessed="
+        + numberRecordsProcessed
+        + ", numberRecordsFailed="
+        + numberRecordsFailed
+        + ", retries="
+        + retries
+        + ", totalProcessingTime="
+        + totalProcessingTime
+        + ", apiActiveProcessingTime="
+        + apiActiveProcessingTime
+        + ", apexProcessingTime="
+        + apexProcessingTime
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    BulkIngestJobInfo that = (BulkIngestJobInfo) o;
+    return numberRecordsProcessed == that.numberRecordsProcessed
+        && numberRecordsFailed == that.numberRecordsFailed
+        && retries == that.retries
+        && Objects.equals(id, that.id)
+        && operation == that.operation
+        && Objects.equals(object, that.object)
+        && Objects.equals(createdById, that.createdById)
+        && Objects.equals(createdDate, that.createdDate)
+        && Objects.equals(systemModstamp, that.systemModstamp)
+        && state == that.state
+        && contentType == that.contentType
+        && Objects.equals(apiVersion, that.apiVersion)
+        && lineEnding == that.lineEnding
+        && columnDelimiter == that.columnDelimiter
+        && Objects.equals(totalProcessingTime, that.totalProcessingTime)
+        && Objects.equals(apiActiveProcessingTime, that.apiActiveProcessingTime)
+        && Objects.equals(apexProcessingTime, that.apexProcessingTime);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        operation,
+        object,
+        createdById,
+        createdDate,
+        systemModstamp,
+        state,
+        contentType,
+        apiVersion,
+        lineEnding,
+        columnDelimiter,
+        numberRecordsProcessed,
+        numberRecordsFailed,
+        retries,
+        totalProcessingTime,
+        apiActiveProcessingTime,
+        apexProcessingTime);
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkIngestOperation.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkIngestOperation.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum BulkIngestOperation {
+  @SerializedName("insert")
+  INSERT,
+  @SerializedName("delete")
+  DELETE,
+  @SerializedName("hardDelete")
+  HARD_DELETE,
+  @SerializedName("update")
+  UPDATE,
+  @SerializedName("upsert")
+  UPSERT,
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkJobState.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkJobState.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum BulkJobState {
+  @SerializedName("Open")
+  OPEN,
+  @SerializedName("UploadComplete")
+  UPLOAD_COMPLETE,
+  @SerializedName("InProgress")
+  IN_PROGRESS,
+  @SerializedName("Aborted")
+  ABORTED,
+  @SerializedName("JobComplete")
+  JOB_COMPLETE,
+  @SerializedName("Failed")
+  FAILED
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkQueryJobInfo.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkQueryJobInfo.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+import com.google.gson.annotations.JsonAdapter;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+public class BulkQueryJobInfo {
+  private final String id;
+  private final BulkQueryOperation operation;
+  private final String object;
+  private final String createdById;
+
+  @JsonAdapter(SalesforceDateTimeStringJsonAdapter.class)
+  private final Instant createdDate;
+
+  @JsonAdapter(SalesforceDateTimeStringJsonAdapter.class)
+  private final Instant systemModstamp;
+
+  private final BulkJobState state;
+  private final ContentType contentType;
+  private final String apiVersion;
+  private final LineEnding lineEnding;
+  private final ColumnDelimiter columnDelimiter;
+  private final long numberRecordsProcessed;
+  private final long retries;
+
+  @JsonAdapter(DurationJsonAdapter.class)
+  private final Duration totalProcessingTime;
+
+  public BulkQueryJobInfo(
+      String id,
+      BulkQueryOperation operation,
+      String object,
+      String createdById,
+      Instant createdDate,
+      Instant systemModstamp,
+      BulkJobState state,
+      ContentType contentType,
+      String apiVersion,
+      LineEnding lineEnding,
+      ColumnDelimiter columnDelimiter,
+      long numberRecordsProcessed,
+      long retries,
+      Duration totalProcessingTime) {
+    this.id = id;
+    this.operation = operation;
+    this.object = object;
+    this.createdById = createdById;
+    this.createdDate = createdDate;
+    this.systemModstamp = systemModstamp;
+    this.state = state;
+    this.contentType = contentType;
+    this.apiVersion = apiVersion;
+    this.lineEnding = lineEnding;
+    this.columnDelimiter = columnDelimiter;
+    this.numberRecordsProcessed = numberRecordsProcessed;
+    this.retries = retries;
+    this.totalProcessingTime = totalProcessingTime;
+  }
+
+  @Override
+  public String toString() {
+    return "BulkQueryJobInfo{"
+        + "id='"
+        + id
+        + '\''
+        + ", operation="
+        + operation
+        + ", object='"
+        + object
+        + '\''
+        + ", createdById='"
+        + createdById
+        + '\''
+        + ", createdDate="
+        + createdDate
+        + ", systemModstamp="
+        + systemModstamp
+        + ", state="
+        + state
+        + ", contentType="
+        + contentType
+        + ", apiVersion='"
+        + apiVersion
+        + '\''
+        + ", lineEnding="
+        + lineEnding
+        + ", columnDelimiter="
+        + columnDelimiter
+        + ", numberRecordsProcessed="
+        + numberRecordsProcessed
+        + ", retries="
+        + retries
+        + ", totalProcessingTime="
+        + totalProcessingTime
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    BulkQueryJobInfo that = (BulkQueryJobInfo) o;
+    return numberRecordsProcessed == that.numberRecordsProcessed
+        && retries == that.retries
+        && Objects.equals(id, that.id)
+        && operation == that.operation
+        && Objects.equals(object, that.object)
+        && Objects.equals(createdById, that.createdById)
+        && Objects.equals(createdDate, that.createdDate)
+        && Objects.equals(systemModstamp, that.systemModstamp)
+        && state == that.state
+        && contentType == that.contentType
+        && Objects.equals(apiVersion, that.apiVersion)
+        && lineEnding == that.lineEnding
+        && columnDelimiter == that.columnDelimiter
+        && Objects.equals(totalProcessingTime, that.totalProcessingTime);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        operation,
+        object,
+        createdById,
+        createdDate,
+        systemModstamp,
+        state,
+        contentType,
+        apiVersion,
+        lineEnding,
+        columnDelimiter,
+        numberRecordsProcessed,
+        retries,
+        totalProcessingTime);
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkQueryOperation.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkQueryOperation.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum BulkQueryOperation {
+  @SerializedName("query")
+  QUERY,
+  @SerializedName("queryAll")
+  QUERY_ALL
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkQueryResults.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/BulkQueryResults.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvTable;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+public class BulkQueryResults {
+  private final String locator;
+  private final CsvTable table;
+
+  public BulkQueryResults(@Nullable String locator, CsvTable table) {
+    this.locator = locator;
+    this.table = table;
+  }
+
+  public Optional<String> getLocator() {
+    return Optional.ofNullable(locator);
+  }
+
+  public CsvTable getTable() {
+    return table;
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/ColumnDelimiter.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/ColumnDelimiter.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+public enum ColumnDelimiter {
+  BACKQUOTE,
+  CARET,
+  COMMA,
+  PIPE,
+  SEMICOLON,
+  TAB,
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/ContentType.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/ContentType.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+public enum ContentType {
+  CSV
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/DurationJsonAdapter.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/DurationJsonAdapter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+import com.google.gson.*;
+import java.lang.reflect.Type;
+import java.time.Duration;
+
+public final class DurationJsonAdapter
+    implements JsonSerializer<Duration>, JsonDeserializer<Duration> {
+
+  @Override
+  public Duration deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    return Duration.ofMillis(json.getAsLong());
+  }
+
+  @Override
+  public JsonElement serialize(
+      Duration duration, Type typeOfSrc, JsonSerializationContext context) {
+    return new JsonPrimitive(duration.toMillis());
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/LineEnding.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/LineEnding.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+public enum LineEnding {
+  LF,
+  CRLF
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/ModifyBulkIngestJobResult.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/ModifyBulkIngestJobResult.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+public final class ModifyBulkIngestJobResult {
+  private final String jobId;
+
+  public ModifyBulkIngestJobResult(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/ModifyBulkQueryJobResult.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/ModifyBulkQueryJobResult.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+public class ModifyBulkQueryJobResult {
+  private final String jobId;
+
+  public ModifyBulkQueryJobResult(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/SalesforceDateTimeStringJsonAdapter.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/SalesforceDateTimeStringJsonAdapter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk;
+
+import com.google.gson.*;
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+public final class SalesforceDateTimeStringJsonAdapter
+    implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
+
+  @Override
+  public JsonElement serialize(Instant instant, Type srcType, JsonSerializationContext context) {
+    return new JsonPrimitive(DATE_TIME_FORMATTER.format(instant));
+  }
+
+  @Override
+  public Instant deserialize(JsonElement json, Type type, JsonDeserializationContext context)
+      throws JsonParseException {
+
+    return Instant.from(DATE_TIME_FORMATTER.parse(json.getAsString()));
+  }
+
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/AbortBulkIngestJobApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/AbortBulkIngestJobApiRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.ErrorResponseParser;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public class AbortBulkIngestJobApiRequest extends JsonRestApiRequest<ModifyBulkIngestJobResult> {
+  private final String jobId;
+
+  public AbortBulkIngestJobApiRequest(String jobId) {
+    this.jobId = jobId;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.PATCH;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "ingest", jobId)
+        .build();
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    JsonObject body = new JsonObject();
+    body.addProperty("state", "Aborted");
+
+    return Optional.of(new JsonRequestBody(new Gson().toJsonTree(body)));
+  }
+
+  @Override
+  public ModifyBulkIngestJobResult processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+    if (statusCode == 200) {
+      return new ModifyBulkIngestJobResult(jobId);
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/AbortBulkQueryJobApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/AbortBulkQueryJobApiRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.ErrorResponseParser;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkQueryJobResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public class AbortBulkQueryJobApiRequest extends JsonRestApiRequest<ModifyBulkQueryJobResult> {
+  private final String jobId;
+
+  public AbortBulkQueryJobApiRequest(String jobId) {
+    this.jobId = jobId;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.PATCH;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "query", jobId)
+        .build();
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    JsonObject body = new JsonObject();
+    body.addProperty("state", "Aborted");
+
+    return Optional.of(new JsonRequestBody(new Gson().toJsonTree(body)));
+  }
+
+  @Override
+  public ModifyBulkQueryJobResult processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+    if (statusCode == 200) {
+      return new ModifyBulkQueryJobResult(jobId);
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CloseBulkIngestJobApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CloseBulkIngestJobApiRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.ErrorResponseParser;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class CloseBulkIngestJobApiRequest
+    extends JsonRestApiRequest<ModifyBulkIngestJobResult> {
+  private final String jobId;
+
+  public CloseBulkIngestJobApiRequest(String jobId) {
+    this.jobId = jobId;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.PATCH;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "ingest", jobId)
+        .build();
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    JsonObject body = new JsonObject();
+    body.addProperty("state", "UploadComplete");
+
+    return Optional.of(new JsonRequestBody(new Gson().toJsonTree(body)));
+  }
+
+  @Override
+  public ModifyBulkIngestJobResult processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+    if (statusCode == 200) {
+      return new ModifyBulkIngestJobResult(jobId);
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CreateBulkIngestJobApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CreateBulkIngestJobApiRequest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.BulkIngestOperation;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class CreateBulkIngestJobApiRequest
+    extends JsonRestApiRequest<ModifyBulkIngestJobResult> {
+  private final String objectType;
+  private final BulkIngestOperation operation;
+
+  public CreateBulkIngestJobApiRequest(String objectType, BulkIngestOperation operation) {
+    this.objectType = objectType;
+    this.operation = operation;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.POST;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "ingest")
+        .build();
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    JsonObject body = new JsonObject();
+    body.addProperty("object", objectType);
+
+    switch (operation) {
+      case INSERT:
+        body.addProperty("operation", "insert");
+        break;
+      case UPDATE:
+        body.addProperty("operation", "update");
+        break;
+      case UPSERT:
+        body.addProperty("operation", "upsert");
+        break;
+      case DELETE:
+        body.addProperty("operation", "delete");
+        break;
+      case HARD_DELETE:
+        body.addProperty("operation", "hard_delete");
+        break;
+      default:
+        throw new IllegalStateException("Unknown bulk ingest operation: " + operation);
+    }
+
+    return Optional.of(new JsonRequestBody(new Gson().toJsonTree(body)));
+  }
+
+  @Override
+  public ModifyBulkIngestJobResult processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+    if (statusCode == 200) {
+      return new ModifyBulkIngestJobResult(body.getAsJsonObject().get("id").getAsString());
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CreateBulkQueryJobApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CreateBulkQueryJobApiRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.ErrorResponseParser;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.BulkQueryOperation;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkQueryJobResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class CreateBulkQueryJobApiRequest
+    extends JsonRestApiRequest<ModifyBulkQueryJobResult> {
+  private final String query;
+  private final BulkQueryOperation operation;
+
+  public CreateBulkQueryJobApiRequest(String query, BulkQueryOperation operation) {
+    this.query = query;
+    this.operation = operation;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.POST;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "query")
+        .build();
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    JsonObject body = new JsonObject();
+    body.addProperty("query", query);
+    body.addProperty("contentType", "CSV");
+    body.addProperty("columnDelimiter", "COMMA");
+    body.addProperty("lineEnding", "LF");
+
+    switch (operation) {
+      case QUERY:
+        body.addProperty("operation", "query");
+        break;
+      case QUERY_ALL:
+        body.addProperty("operation", "queryAll");
+        break;
+      default:
+        throw new IllegalStateException("Unknown bulk query operation: " + operation);
+    }
+
+    return Optional.of(new JsonRequestBody(new Gson().toJsonTree(body)));
+  }
+
+  @Override
+  public ModifyBulkQueryJobResult processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+    if (statusCode == 200) {
+      return new ModifyBulkQueryJobResult(body.getAsJsonObject().get("id").getAsString());
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/DeleteBulkIngestJobApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/DeleteBulkIngestJobApiRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.JsonElement;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.ErrorResponseParser;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class DeleteBulkIngestJobApiRequest
+    extends JsonRestApiRequest<ModifyBulkIngestJobResult> {
+  private final String jobId;
+
+  public DeleteBulkIngestJobApiRequest(String jobId) {
+    this.jobId = jobId;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.DELETE;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "ingest", jobId)
+        .build();
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    return Optional.empty();
+  }
+
+  @Override
+  public ModifyBulkIngestJobResult processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+    if (statusCode == 204) {
+      return new ModifyBulkIngestJobResult(jobId);
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/DeleteBulkQueryJobApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/DeleteBulkQueryJobApiRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.JsonElement;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.ErrorResponseParser;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkQueryJobResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class DeleteBulkQueryJobApiRequest
+    extends JsonRestApiRequest<ModifyBulkQueryJobResult> {
+  private final String jobId;
+
+  public DeleteBulkQueryJobApiRequest(String jobId) {
+    this.jobId = jobId;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.DELETE;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "query", jobId)
+        .build();
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    return Optional.empty();
+  }
+
+  @Override
+  public ModifyBulkQueryJobResult processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+    if (statusCode == 204) {
+      return new ModifyBulkQueryJobResult(jobId);
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkIngestJobInfoApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkIngestJobInfoApiRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.ErrorResponseParser;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.BulkIngestJobInfo;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class GetBulkIngestJobInfoApiRequest extends JsonRestApiRequest<BulkIngestJobInfo> {
+  private final String jobId;
+
+  public GetBulkIngestJobInfoApiRequest(String jobId) {
+    this.jobId = jobId;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.GET;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "ingest", jobId)
+        .build();
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    return Optional.empty();
+  }
+
+  @Override
+  public BulkIngestJobInfo processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+
+    if (statusCode == 200) {
+      return new Gson().fromJson(body, BulkIngestJobInfo.class);
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkIngestJobResultsApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkIngestJobResultsApiRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvResponseRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvTable;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class GetBulkIngestJobResultsApiRequest
+    extends CsvResponseRestApiRequest<CsvTable, JsonRequestBody> {
+  private final String jobId;
+  private final RecordStatus status;
+
+  public GetBulkIngestJobResultsApiRequest(String jobId, RecordStatus status) {
+    this.jobId = jobId;
+    this.status = status;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.GET;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    String statusString;
+    switch (status) {
+      case FAILED:
+        statusString = "failedResults";
+        break;
+      case SUCCESSFUL:
+        statusString = "successfulResults";
+        break;
+      case UNPROCESSED:
+        statusString = "unprocessedrecords";
+        break;
+      default:
+        throw new IllegalStateException("Missing URL mapping for job status: " + status);
+    }
+
+    return new URIBuilder(baseUri)
+        .setPathSegments(
+            "services", "data", "v" + apiVersion, "jobs", "ingest", jobId, statusString)
+        .build();
+  }
+
+  @Override
+  public CsvTable processResponse(int statusCode, Map<String, String> headers, CsvTable body)
+      throws RestApiErrorsException {
+    if (statusCode == 200) {
+      return body;
+    }
+
+    throw new RestApiErrorsException(Collections.emptyList());
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    return Optional.empty();
+  }
+
+  public enum RecordStatus {
+    UNPROCESSED,
+    FAILED,
+    SUCCESSFUL
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkQueryJobInfoApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkQueryJobInfoApiRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.ErrorResponseParser;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.BulkQueryJobInfo;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class GetBulkQueryJobInfoApiRequest extends JsonRestApiRequest<BulkQueryJobInfo> {
+  private final String jobId;
+
+  public GetBulkQueryJobInfoApiRequest(String jobId) {
+    this.jobId = jobId;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.GET;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "query", jobId)
+        .build();
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    return Optional.empty();
+  }
+
+  @Override
+  public BulkQueryJobInfo processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+
+    if (statusCode == 200) {
+      return new Gson().fromJson(body, BulkQueryJobInfo.class);
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkQueryJobResultsApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkQueryJobResultsApiRequest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.BulkQueryResults;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvResponseRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvTable;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class GetBulkQueryJobResultsApiRequest
+    extends CsvResponseRestApiRequest<BulkQueryResults, JsonRequestBody> {
+  private final String jobId;
+  private final String locator;
+  private final Long maxRecords;
+
+  public GetBulkQueryJobResultsApiRequest(
+      String jobId, @Nullable String locator, @Nullable Long maxRecords) {
+    this.jobId = jobId;
+    this.locator = locator;
+    this.maxRecords = maxRecords;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.GET;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    URIBuilder uriBuilder =
+        new URIBuilder(baseUri)
+            .setPathSegments(
+                "services", "data", "v" + apiVersion, "jobs", "query", jobId, "results");
+
+    if (locator != null) {
+      uriBuilder.addParameter("locator", locator);
+    }
+
+    if (maxRecords != null) {
+      uriBuilder.addParameter("maxRecords", maxRecords.toString());
+    }
+
+    return uriBuilder.build();
+  }
+
+  @Override
+  public BulkQueryResults processResponse(
+      int statusCode, Map<String, String> headers, CsvTable body) throws RestApiErrorsException {
+    if (statusCode == 200) {
+      // The API will always send a locator header, even if there is no locator. In such cases, the
+      // value will be the "null" as a string.
+      String locator = headers.get("Sforce-Locator");
+      if (locator.equals("null")) {
+        locator = null;
+      }
+
+      return new BulkQueryResults(locator, body);
+    }
+
+    throw new RestApiErrorsException(Collections.emptyList());
+  }
+
+  @Override
+  public Optional<JsonRequestBody> getBody() {
+    return Optional.empty();
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/UploadBulkIngestJobDataApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/UploadBulkIngestJobDataApiRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvTable;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.utils.URIBuilder;
+
+public final class UploadBulkIngestJobDataApiRequest
+    implements RestApiRequest<ModifyBulkIngestJobResult, CsvRequestBody, JsonElement> {
+  private final String jobId;
+  private final CsvTable table;
+
+  public UploadBulkIngestJobDataApiRequest(String jobId, CsvTable table) {
+    this.jobId = jobId;
+    this.table = table;
+  }
+
+  @Override
+  public HttpMethod getHttpMethod() {
+    return HttpMethod.PUT;
+  }
+
+  @Override
+  public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
+    return new URIBuilder(baseUri)
+        .setPathSegments("services", "data", "v" + apiVersion, "jobs", "ingest", jobId, "batches")
+        .build();
+  }
+
+  @Override
+  public Optional<CsvRequestBody> getBody() {
+    return Optional.of(new CsvRequestBody(table));
+  }
+
+  @Override
+  public ModifyBulkIngestJobResult processResponse(
+      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+    if (statusCode == 201) {
+      return new ModifyBulkIngestJobResult(jobId);
+    } else {
+      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+    }
+  }
+
+  @Override
+  public JsonElement parseBody(byte[] body) throws BodyParsingException {
+    try {
+      return new Gson()
+          .fromJson(new InputStreamReader(new ByteArrayInputStream(body)), JsonElement.class);
+    } catch (JsonSyntaxException e) {
+      throw new BodyParsingException(e);
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvException.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.csv;
+
+public final class CsvException extends Exception {
+  public CsvException(String message) {
+    super(message);
+  }
+
+  public CsvException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public CsvException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvRequestBody.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvRequestBody.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.csv;
+
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiRequestBody;
+import org.apache.http.entity.ContentType;
+
+public class CsvRequestBody implements RestApiRequestBody {
+  private final CsvTable table;
+
+  public CsvRequestBody(CsvTable table) {
+    this.table = table;
+  }
+
+  @Override
+  public ContentType getContentType() {
+    return ContentType.create("text/csv");
+  }
+
+  @Override
+  public byte[] getRequestContents() {
+    return CsvTableUtils.serialize(table);
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvResponseRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvResponseRestApiRequest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.csv;
+
+import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
+
+public abstract class CsvResponseRestApiRequest<T, A extends RestApiRequestBody>
+    implements RestApiRequest<T, A, CsvTable> {
+
+  @Override
+  public CsvTable parseBody(byte[] body) throws BodyParsingException {
+    try {
+      return CsvTableUtils.deserialize(body);
+    } catch (CsvException e) {
+      throw new BodyParsingException("Could not parse body as CSV!", e);
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvTable.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvTable.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.csv;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class CsvTable {
+  private final List<String> headers;
+  private final List<List<String>> rows;
+
+  public CsvTable(List<String> headers, List<List<String>> rows) {
+    this.headers = Collections.unmodifiableList(new ArrayList<>(headers));
+
+    List<List<String>> copiedRows = new ArrayList<>();
+    for (List<String> row : rows) {
+      List<String> copiedRow = new ArrayList<>();
+
+      for (int i = 0; i < headers.size(); i++) {
+        if (i < row.size()) {
+          copiedRow.add(row.get(i));
+        } else {
+          copiedRow.add(null);
+        }
+      }
+
+      copiedRows.add(Collections.unmodifiableList(copiedRow));
+    }
+
+    this.rows = Collections.unmodifiableList(copiedRows);
+  }
+
+  public List<String> getHeaders() {
+    return headers;
+  }
+
+  public List<List<String>> getRows() {
+    return rows;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CsvTable csvTable = (CsvTable) o;
+    return Objects.equals(headers, csvTable.headers) && Objects.equals(rows, csvTable.rows);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(headers, rows);
+  }
+
+  @Override
+  public String toString() {
+    return "CsvTable{" + "headers=" + headers + ", rows=" + rows + '}';
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvTableUtils.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvTableUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.csv;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+
+public final class CsvTableUtils {
+
+  public static CsvTable deserialize(byte[] data) throws CsvException {
+    try {
+      CSVFormat format =
+          CSVFormat.Builder.create(CSVFormat.DEFAULT).setRecordSeparator('\n').build();
+
+      CSVParser parser =
+          CSVParser.parse(new ByteArrayInputStream(data), StandardCharsets.UTF_8, format);
+
+      List<List<String>> rows =
+          parser.getRecords().stream().map(CSVRecord::toList).collect(Collectors.toList());
+
+      return new CsvTable(rows.get(0), rows.subList(1, rows.size()));
+    } catch (IOException e) {
+      throw new CsvException(e);
+    }
+  }
+
+  public static byte[] serialize(CsvTable table) {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    CSVFormat csvFormat =
+        CSVFormat.Builder.create(CSVFormat.DEFAULT)
+            .setHeader(table.getHeaders().toArray(new String[0]))
+            .setRecordSeparator('\n')
+            .build();
+
+    try (CSVPrinter csvPrinter = new CSVPrinter(new OutputStreamWriter(outputStream), csvFormat)) {
+      for (List<String> row : table.getRows()) {
+        csvPrinter.printRecord(row);
+      }
+    } catch (IOException e) {
+      // The CSV library is designed to work with IO streams directly. Since we write into memory,
+      // IO exceptions cannot occur.
+      throw new IllegalStateException("Unexpected IOException while serializing CSV data!", e);
+    }
+
+    return outputStream.toByteArray();
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/json/JsonRequestBody.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/json/JsonRequestBody.java
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-package com.salesforce.functions.jvm.runtime.sdk.restapi;
+package com.salesforce.functions.jvm.runtime.sdk.restapi.json;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiRequestBody;
 import java.nio.charset.StandardCharsets;
 import org.apache.http.entity.ContentType;
 

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/json/JsonRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/json/JsonRestApiRequest.java
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-package com.salesforce.functions.jvm.runtime.sdk.restapi;
+package com.salesforce.functions.jvm.runtime.sdk.restapi.json;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.BodyParsingException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiRequest;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/AbstractQueryRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/AbstractQueryRestApiRequest.java
@@ -4,13 +4,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-package com.salesforce.functions.jvm.runtime.sdk.restapi;
+package com.salesforce.functions.jvm.runtime.sdk.restapi.requests;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.reflect.TypeToken;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.ErrorResponseParser;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryRecordResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.Record;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/CompositeGraphRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/CompositeGraphRestApiRequest.java
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-package com.salesforce.functions.jvm.runtime.sdk.restapi;
+package com.salesforce.functions.jvm.runtime.sdk.restapi.requests;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -12,6 +12,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.reflect.TypeToken;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/CreateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/CreateRecordRestApiRequest.java
@@ -4,37 +4,37 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-package com.salesforce.functions.jvm.runtime.sdk.restapi;
+package com.salesforce.functions.jvm.runtime.sdk.restapi.requests;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.http.client.utils.URIBuilder;
 
-public class UpdateRecordRestApiRequest extends JsonRestApiRequest<ModifyRecordResult> {
-  private final String id;
+public class CreateRecordRestApiRequest extends JsonRestApiRequest<ModifyRecordResult> {
   private final String type;
   private final Map<String, JsonElement> values;
 
-  public UpdateRecordRestApiRequest(String id, String type, Map<String, JsonElement> values) {
-    this.id = id;
+  public CreateRecordRestApiRequest(String type, Map<String, JsonElement> values) {
     this.type = type;
-    this.values = new HashMap<>(values);
+    this.values = values;
   }
 
   @Override
   public HttpMethod getHttpMethod() {
-    return HttpMethod.PATCH;
+    return HttpMethod.POST;
   }
 
   @Override
   public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
     return new URIBuilder(baseUri)
-        .setPathSegments("services", "data", "v" + apiVersion, "sobjects", this.type, this.id)
+        .setPathSegments("services", "data", "v" + apiVersion, "sobjects", type)
         .build();
   }
 
@@ -47,8 +47,8 @@ public class UpdateRecordRestApiRequest extends JsonRestApiRequest<ModifyRecordR
   public ModifyRecordResult processResponse(
       int statusCode, Map<String, String> headers, JsonElement jsonRequestBody)
       throws RestApiErrorsException {
-    if (statusCode == 204) {
-      return new ModifyRecordResult(id);
+    if (statusCode == 201) {
+      return new ModifyRecordResult(jsonRequestBody.getAsJsonObject().get("id").getAsString());
     } else {
       throw new RestApiErrorsException(ErrorResponseParser.parse(jsonRequestBody));
     }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/DeleteRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/DeleteRecordRestApiRequest.java
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-package com.salesforce.functions.jvm.runtime.sdk.restapi;
+package com.salesforce.functions.jvm.runtime.sdk.restapi.requests;
 
 import com.google.gson.JsonElement;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/QueryNextRecordsRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/QueryNextRecordsRestApiRequest.java
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-package com.salesforce.functions.jvm.runtime.sdk.restapi;
+package com.salesforce.functions.jvm.runtime.sdk.restapi.requests;
 
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/QueryRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/QueryRecordRestApiRequest.java
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-package com.salesforce.functions.jvm.runtime.sdk.restapi;
+package com.salesforce.functions.jvm.runtime.sdk.restapi.requests;
 
+import com.salesforce.functions.jvm.runtime.sdk.restapi.HttpMethod;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/UpdateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/requests/UpdateRecordRestApiRequest.java
@@ -4,34 +4,40 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-package com.salesforce.functions.jvm.runtime.sdk.restapi;
+package com.salesforce.functions.jvm.runtime.sdk.restapi.requests;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRequestBody;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.http.client.utils.URIBuilder;
 
-public class CreateRecordRestApiRequest extends JsonRestApiRequest<ModifyRecordResult> {
+public class UpdateRecordRestApiRequest extends JsonRestApiRequest<ModifyRecordResult> {
+  private final String id;
   private final String type;
   private final Map<String, JsonElement> values;
 
-  public CreateRecordRestApiRequest(String type, Map<String, JsonElement> values) {
+  public UpdateRecordRestApiRequest(String id, String type, Map<String, JsonElement> values) {
+    this.id = id;
     this.type = type;
-    this.values = values;
+    this.values = new HashMap<>(values);
   }
 
   @Override
   public HttpMethod getHttpMethod() {
-    return HttpMethod.POST;
+    return HttpMethod.PATCH;
   }
 
   @Override
   public URI createUri(URI baseUri, String apiVersion) throws URISyntaxException {
     return new URIBuilder(baseUri)
-        .setPathSegments("services", "data", "v" + apiVersion, "sobjects", type)
+        .setPathSegments("services", "data", "v" + apiVersion, "sobjects", this.type, this.id)
         .build();
   }
 
@@ -44,8 +50,8 @@ public class CreateRecordRestApiRequest extends JsonRestApiRequest<ModifyRecordR
   public ModifyRecordResult processResponse(
       int statusCode, Map<String, String> headers, JsonElement jsonRequestBody)
       throws RestApiErrorsException {
-    if (statusCode == 201) {
-      return new ModifyRecordResult(jsonRequestBody.getAsJsonObject().get("id").getAsString());
+    if (statusCode == 204) {
+      return new ModifyRecordResult(id);
     } else {
       throw new RestApiErrorsException(ErrorResponseParser.parse(jsonRequestBody));
     }

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/BulkApiTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/BulkApiTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import org.junit.Rule;
+
+public class BulkApiTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
@@ -14,6 +14,8 @@ import static org.hamcrest.Matchers.hasEntry;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.json.JsonRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.*;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCreateTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.is;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.CreateRecordRestApiRequest;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiDeleteTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiDeleteTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.DeleteRecordRestApiRequest;
 import java.io.IOException;
 import java.net.URI;
 import org.junit.Assert;

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiQueryTest.java
@@ -14,6 +14,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.QueryNextRecordsRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.QueryRecordRestApiRequest;
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.QueryRecordRestApiRequest;
 import java.io.IOException;
 import java.net.URI;
 import org.junit.Assert;

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiUpdateTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.is;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.requests.UpdateRecordRestApiRequest;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/AbortBulkIngestJobApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/AbortBulkIngestJobApiRequestTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiError;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AbortBulkIngestJobApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void abort() throws RestApiErrorsException, IOException, RestApiException {
+    AbortBulkIngestJobApiRequest request = new AbortBulkIngestJobApiRequest("7507Q000009f4YjQAI");
+    ModifyBulkIngestJobResult result = restApi.execute(request);
+
+    assertThat(result.getJobId(), is(equalTo("7507Q000009f4YjQAI")));
+  }
+
+  @Test
+  public void abortNonExistent() throws IOException, RestApiException {
+    AbortBulkIngestJobApiRequest request = new AbortBulkIngestJobApiRequest("7507Q000009f4YjXXX");
+
+    try {
+      restApi.execute(request);
+    } catch (RestApiErrorsException e) {
+      RestApiError error = e.getApiErrors().get(0);
+
+      assertThat(error.getMessage(), is(equalTo("The requested resource does not exist")));
+
+      assertThat(error.getErrorCode(), is(equalTo("NOT_FOUND")));
+
+      return;
+    }
+
+    Assert.fail("Expected exception!");
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CloseBulkIngestJobApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CloseBulkIngestJobApiRequestTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CloseBulkIngestJobApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void close() throws RestApiErrorsException, IOException, RestApiException {
+    CloseBulkIngestJobApiRequest request = new CloseBulkIngestJobApiRequest("7507Q000009f52jQAA");
+    ModifyBulkIngestJobResult result = restApi.execute(request);
+
+    assertThat(result.getJobId(), is(equalTo("7507Q000009f52jQAA")));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CreateBulkIngestJobApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CreateBulkIngestJobApiRequestTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.BulkIngestOperation;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CreateBulkIngestJobApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void create() throws RestApiErrorsException, IOException, RestApiException {
+    CreateBulkIngestJobApiRequest request =
+        new CreateBulkIngestJobApiRequest("Asset", BulkIngestOperation.INSERT);
+    ModifyBulkIngestJobResult result = restApi.execute(request);
+
+    assertThat(result.getJobId(), is(equalTo("7507Q000009f52jQAA")));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CreateBulkQueryJobApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/CreateBulkQueryJobApiRequestTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.BulkQueryOperation;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkQueryJobResult;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CreateBulkQueryJobApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void create() throws RestApiErrorsException, IOException, RestApiException {
+    CreateBulkQueryJobApiRequest request =
+        new CreateBulkQueryJobApiRequest(
+            "SELECT Name, Type, Industry FROM Account", BulkQueryOperation.QUERY);
+    ModifyBulkQueryJobResult result = restApi.execute(request);
+
+    assertThat(result.getJobId(), is(equalTo("7507Q000009f8jvQAA")));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/DeleteBulkIngestJobApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/DeleteBulkIngestJobApiRequestTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DeleteBulkIngestJobApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void close() throws RestApiErrorsException, IOException, RestApiException {
+    DeleteBulkIngestJobApiRequest request = new DeleteBulkIngestJobApiRequest("7507Q000009f52jQAA");
+    ModifyBulkIngestJobResult result = restApi.execute(request);
+
+    assertThat(result.getJobId(), is(equalTo("7507Q000009f52jQAA")));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/DeleteBulkQueryJobApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/DeleteBulkQueryJobApiRequestTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkQueryJobResult;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DeleteBulkQueryJobApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void delete() throws RestApiErrorsException, IOException, RestApiException {
+    DeleteBulkQueryJobApiRequest request = new DeleteBulkQueryJobApiRequest("7507Q000009f8jvQAA");
+    ModifyBulkQueryJobResult result = restApi.execute(request);
+
+    assertThat(result.getJobId(), is(equalTo("7507Q000009f8jvQAA")));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkIngestJobInfoApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkIngestJobInfoApiRequestTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.*;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetBulkIngestJobInfoApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void close() throws RestApiErrorsException, IOException, RestApiException {
+    GetBulkIngestJobInfoApiRequest request =
+        new GetBulkIngestJobInfoApiRequest("7507Q000009f52jQAA");
+    BulkIngestJobInfo result = restApi.execute(request);
+
+    assertThat(
+        result,
+        is(
+            equalTo(
+                new BulkIngestJobInfo(
+                    "7507Q000009f52jQAA",
+                    BulkIngestOperation.INSERT,
+                    "Account",
+                    "0057Q0000037T8QQAU",
+                    Instant.parse("2023-01-26T10:09:27Z"),
+                    Instant.parse("2023-01-26T10:09:49Z"),
+                    BulkJobState.FAILED,
+                    ContentType.CSV,
+                    "53.0",
+                    LineEnding.LF,
+                    ColumnDelimiter.COMMA,
+                    0,
+                    0,
+                    0,
+                    Duration.ofMillis(0),
+                    Duration.ofMillis(0),
+                    Duration.ofMillis(0)))));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkIngestJobResultsApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkIngestJobResultsApiRequestTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvTable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetBulkIngestJobResultsApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void successful() throws RestApiErrorsException, IOException, RestApiException {
+    GetBulkIngestJobResultsApiRequest request =
+        new GetBulkIngestJobResultsApiRequest(
+            "7507Q000009f52jQAA", GetBulkIngestJobResultsApiRequest.RecordStatus.SUCCESSFUL);
+    CsvTable table = restApi.execute(request);
+
+    List<String> expectedHeaders = new ArrayList<>();
+    expectedHeaders.add("sf__Id");
+    expectedHeaders.add("sf__Created");
+    expectedHeaders.add("Name");
+    expectedHeaders.add("Employees");
+
+    assertThat(table, is(equalTo(new CsvTable(expectedHeaders, new ArrayList<>()))));
+  }
+
+  @Test
+  public void failed() throws RestApiErrorsException, IOException, RestApiException {
+    GetBulkIngestJobResultsApiRequest request =
+        new GetBulkIngestJobResultsApiRequest(
+            "7507Q000009f52jQAA", GetBulkIngestJobResultsApiRequest.RecordStatus.FAILED);
+    CsvTable table = restApi.execute(request);
+
+    List<String> expectedHeaders = new ArrayList<>();
+    expectedHeaders.add("sf__Id");
+    expectedHeaders.add("sf__Error");
+    expectedHeaders.add("Name");
+    expectedHeaders.add("Employees");
+
+    assertThat(table, is(equalTo(new CsvTable(expectedHeaders, new ArrayList<>()))));
+  }
+
+  @Test
+  public void unprocessed() throws RestApiErrorsException, IOException, RestApiException {
+    GetBulkIngestJobResultsApiRequest request =
+        new GetBulkIngestJobResultsApiRequest(
+            "7507Q000009f52jQAA", GetBulkIngestJobResultsApiRequest.RecordStatus.UNPROCESSED);
+    CsvTable table = restApi.execute(request);
+
+    List<String> expectedHeaders = new ArrayList<>();
+    expectedHeaders.add("Name");
+    expectedHeaders.add("Employees");
+
+    List<String> row1 = new ArrayList<>();
+    row1.add("Foo");
+    row1.add("12");
+
+    List<String> row2 = new ArrayList<>();
+    row2.add("Bar");
+    row2.add("1138");
+
+    List<List<String>> expectedRows = new ArrayList<>();
+    expectedRows.add(row1);
+    expectedRows.add(row2);
+
+    assertThat(table, is(equalTo(new CsvTable(expectedHeaders, expectedRows))));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkQueryJobInfoApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkQueryJobInfoApiRequestTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.*;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetBulkQueryJobInfoApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void getInfo() throws RestApiErrorsException, IOException, RestApiException {
+    GetBulkQueryJobInfoApiRequest request = new GetBulkQueryJobInfoApiRequest("7507Q000009f8jvQAA");
+    BulkQueryJobInfo result = restApi.execute(request);
+
+    assertThat(
+        result,
+        is(
+            equalTo(
+                new BulkQueryJobInfo(
+                    "7507Q000009f8jvQAA",
+                    BulkQueryOperation.QUERY,
+                    "Account",
+                    "0057Q0000037T8QQAU",
+                    Instant.parse("2023-01-26T14:50:10Z"),
+                    Instant.parse("2023-01-26T14:50:12Z"),
+                    BulkJobState.JOB_COMPLETE,
+                    ContentType.CSV,
+                    "53.0",
+                    LineEnding.LF,
+                    ColumnDelimiter.COMMA,
+                    13,
+                    0,
+                    Duration.ofMillis(176)))));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkQueryJobResultsApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/GetBulkQueryJobResultsApiRequestTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static com.spotify.hamcrest.optional.OptionalMatchers.emptyOptional;
+import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.BulkQueryResults;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvTable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetBulkQueryJobResultsApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void results() throws RestApiErrorsException, IOException, RestApiException {
+    GetBulkQueryJobResultsApiRequest request =
+        new GetBulkQueryJobResultsApiRequest("7507Q000009f8jvQAA", null, null);
+    BulkQueryResults results = restApi.execute(request);
+
+    List<String> expectedHeaders = Arrays.asList("Name", "Type", "Industry");
+
+    List<List<String>> expectedRows = new ArrayList<>();
+    expectedRows.add(Arrays.asList("Beispielaccount für Ansprüche", "", ""));
+    expectedRows.add(Arrays.asList("Edge Communications", "Customer - Direct", "Electronics"));
+    expectedRows.add(
+        Arrays.asList("Burlington Textiles Corp of America", "Customer - Direct", "Apparel"));
+    expectedRows.add(
+        Arrays.asList("Pyramid Construction Inc.", "Customer - Channel", "Construction"));
+    expectedRows.add(Arrays.asList("Dickenson plc", "Customer - Channel", "Consulting"));
+    expectedRows.add(
+        Arrays.asList("Grand Hotels & Resorts Ltd", "Customer - Direct", "Hospitality"));
+    expectedRows.add(Arrays.asList("United Oil & Gas Corp.", "Customer - Direct", "Energy"));
+    expectedRows.add(
+        Arrays.asList("Express Logistics and Transport", "Customer - Channel", "Transportation"));
+    expectedRows.add(Arrays.asList("University of Arizona", "Customer - Direct", "Education"));
+    expectedRows.add(Arrays.asList("United Oil & Gas, UK", "Customer - Direct", "Energy"));
+    expectedRows.add(Arrays.asList("United Oil & Gas, Singapore", "Customer - Direct", "Energy"));
+    expectedRows.add(Arrays.asList("GenePoint", "Customer - Channel", "Biotechnology"));
+    expectedRows.add(Arrays.asList("sForce", "", ""));
+
+    assertThat(results.getLocator(), is(emptyOptional()));
+    assertThat(results.getTable(), is(equalTo(new CsvTable(expectedHeaders, expectedRows))));
+  }
+
+  @Test
+  public void resultsLimited() throws RestApiErrorsException, IOException, RestApiException {
+    GetBulkQueryJobResultsApiRequest request =
+        new GetBulkQueryJobResultsApiRequest("7507Q000009f9tHQAQ", null, 10L);
+    BulkQueryResults results = restApi.execute(request);
+
+    List<String> expectedHeaders = Arrays.asList("Name", "Type", "Industry");
+
+    List<List<String>> expectedRows = new ArrayList<>();
+    expectedRows.add(Arrays.asList("Beispielaccount für Ansprüche", "", ""));
+    expectedRows.add(Arrays.asList("Edge Communications", "Customer - Direct", "Electronics"));
+    expectedRows.add(
+        Arrays.asList("Burlington Textiles Corp of America", "Customer - Direct", "Apparel"));
+    expectedRows.add(
+        Arrays.asList("Pyramid Construction Inc.", "Customer - Channel", "Construction"));
+    expectedRows.add(Arrays.asList("Dickenson plc", "Customer - Channel", "Consulting"));
+    expectedRows.add(
+        Arrays.asList("Grand Hotels & Resorts Ltd", "Customer - Direct", "Hospitality"));
+    expectedRows.add(Arrays.asList("United Oil & Gas Corp.", "Customer - Direct", "Energy"));
+    expectedRows.add(
+        Arrays.asList("Express Logistics and Transport", "Customer - Channel", "Transportation"));
+    expectedRows.add(Arrays.asList("University of Arizona", "Customer - Direct", "Education"));
+    expectedRows.add(Arrays.asList("United Oil & Gas, UK", "Customer - Direct", "Energy"));
+
+    assertThat(results.getLocator(), is(optionalWithValue(equalTo("MTA"))));
+    assertThat(results.getTable(), is(equalTo(new CsvTable(expectedHeaders, expectedRows))));
+  }
+
+  @Test
+  public void resultsLimitedNext() throws RestApiErrorsException, IOException, RestApiException {
+    GetBulkQueryJobResultsApiRequest request =
+        new GetBulkQueryJobResultsApiRequest("7507Q000009f9tHQAQ", "MTA", null);
+    BulkQueryResults results = restApi.execute(request);
+
+    List<String> expectedHeaders = Arrays.asList("Name", "Type", "Industry");
+
+    List<List<String>> expectedRows = new ArrayList<>();
+    expectedRows.add(Arrays.asList("United Oil & Gas, Singapore", "Customer - Direct", "Energy"));
+    expectedRows.add(Arrays.asList("GenePoint", "Customer - Channel", "Biotechnology"));
+    expectedRows.add(Arrays.asList("sForce", "", ""));
+
+    assertThat(results.getLocator(), is(emptyOptional()));
+    assertThat(results.getTable(), is(equalTo(new CsvTable(expectedHeaders, expectedRows))));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/UploadBulkIngestJobDataApiRequestTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/bulk/requests/UploadBulkIngestJobDataApiRequestTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.requests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.bulk.ModifyBulkIngestJobResult;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.csv.CsvTable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class UploadBulkIngestJobDataApiRequestTest {
+  @Rule public WireMockRule wireMock = new WireMockRule();
+
+  private final RestApi restApi =
+      new RestApi(
+          URI.create("http://localhost:8080/"),
+          "53.0",
+          "00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS");
+
+  @Test
+  public void upload() throws RestApiErrorsException, IOException, RestApiException {
+    List<String> headers = new ArrayList<>();
+    headers.add("Name");
+    headers.add("Employees");
+
+    List<List<String>> rows = new ArrayList<>();
+    List<String> row1 = new ArrayList<>();
+    row1.add("Foo");
+    row1.add("12");
+    rows.add(row1);
+
+    List<String> row2 = new ArrayList<>();
+    row2.add("Bar");
+    row2.add("1138");
+    rows.add(row2);
+
+    UploadBulkIngestJobDataApiRequest request =
+        new UploadBulkIngestJobDataApiRequest("7507Q000009f52jQAA", new CsvTable(headers, rows));
+    ModifyBulkIngestJobResult result = restApi.execute(request);
+
+    assertThat(result.getJobId(), is(equalTo("7507Q000009f52jQAA")));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvRequestBodyTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvRequestBodyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.csv;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class CsvRequestBodyTest {
+  @Test
+  public void basic() {
+
+    List<String> headers = new ArrayList<>();
+    headers.add("Foo");
+    headers.add("Bar");
+    headers.add("Baz");
+
+    List<String> row1 = new ArrayList<>();
+    row1.add("f1");
+    row1.add("b1");
+    row1.add("b1");
+
+    List<String> row2 = new ArrayList<>();
+    row2.add("f2");
+    row2.add("b2");
+    row2.add("b2");
+
+    List<String> row3 = new ArrayList<>();
+    row3.add("f3");
+    row3.add("b3");
+    row3.add("b3");
+
+    List<List<String>> rows = new ArrayList<>();
+    rows.add(row1);
+    rows.add(row2);
+    rows.add(row3);
+
+    CsvTable csvTable = new CsvTable(headers, rows);
+
+    CsvRequestBody body = new CsvRequestBody(csvTable);
+    assertThat(body.getContentType().getMimeType(), is(equalTo("text/csv")));
+    assertThat(
+        new String(body.getRequestContents(), StandardCharsets.UTF_8),
+        is(equalTo("Foo,Bar,Baz\nf1,b1,b1\nf2,b2,b2\nf3,b3,b3\n")));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvTableUtilsTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/csv/CsvTableUtilsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi.csv;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class CsvTableUtilsTest {
+  @Test
+  public void baseSerialize() {
+    List<String> headers = new ArrayList<>();
+    headers.add("Foo");
+    headers.add("Bar");
+    headers.add("Baz");
+
+    List<String> row1 = new ArrayList<>();
+    row1.add("f1");
+    row1.add("b1");
+    row1.add("b1");
+
+    List<String> row2 = new ArrayList<>();
+    row2.add("f2");
+    row2.add("b2");
+    row2.add("b2");
+
+    List<String> row3 = new ArrayList<>();
+    row3.add("f3");
+    row3.add("b3");
+    row3.add("b3");
+
+    List<List<String>> rows = new ArrayList<>();
+    rows.add(row1);
+    rows.add(row2);
+    rows.add(row3);
+
+    CsvTable csvTable = new CsvTable(headers, rows);
+
+    assertThat(
+        new String(CsvTableUtils.serialize(csvTable), StandardCharsets.UTF_8),
+        is(equalTo("Foo,Bar,Baz\nf1,b1,b1\nf2,b2,b2\nf3,b3,b3\n")));
+  }
+
+  @Test
+  public void baseDeserialize() throws CsvException {
+    CsvTable table =
+        CsvTableUtils.deserialize("Foo,Bar,Baz\r\na,b,c\r\n".getBytes(StandardCharsets.UTF_8));
+
+    List<String> expectedHeaders = new ArrayList<>();
+    expectedHeaders.add("Foo");
+    expectedHeaders.add("Bar");
+    expectedHeaders.add("Baz");
+
+    List<List<String>> expectedRows = new ArrayList<>();
+    List<String> expectedRow1 = new ArrayList<>();
+    expectedRow1.add("a");
+    expectedRow1.add("b");
+    expectedRow1.add("c");
+
+    expectedRows.add(expectedRow1);
+
+    assertThat(table.getHeaders(), is(equalTo(expectedHeaders)));
+    assertThat(table.getRows(), is(equalTo(expectedRows)));
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-abort-nonexistent.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-abort-nonexistent.json
@@ -1,0 +1,36 @@
+{
+  "id" : "d31f2edb-3195-3b52-a0d8-a2285a482663",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/ingest/7507Q000009f4YjXXX",
+    "method" : "PATCH",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\n\t\"state\":\"Aborted\"\n}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "[{\"errorCode\":\"NOT_FOUND\",\"message\":\"The requested resource does not exist\"}]",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 09:40:53 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=hrybOp1dEe2OzalPKBZyRA; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 09:40:53 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=13/15000",
+      "Content-Type" : "application/json;charset=UTF-8"
+    }
+  },
+  "uuid" : "d31f2edb-3195-3b52-a0d8-a2285a482663"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-abort.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-abort.json
@@ -1,0 +1,36 @@
+{
+  "id" : "0990f491-9c9b-389e-b358-59185f499ce2",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/ingest/7507Q000009f4YjQAI",
+    "method" : "PATCH",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\n\t\"state\":\"Aborted\"\n}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"7507Q000009f4YjQAI\",\"operation\":\"insert\",\"object\":\"Asset\",\"createdById\":\"0057Q0000037T8QQAU\",\"createdDate\":\"2023-01-26T09:26:51.000+0000\",\"systemModstamp\":\"2023-01-26T09:26:51.000+0000\",\"state\":\"Aborted\",\"concurrencyMode\":\"Parallel\",\"contentType\":\"CSV\",\"apiVersion\":53.0}",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 09:39:03 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=ROlCAp1dEe21JP0aIyCpHA; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 09:39:03 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=12/15000",
+      "Content-Type" : "application/json;charset=UTF-8"
+    }
+  },
+  "uuid" : "0990f491-9c9b-389e-b358-59185f499ce2"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-close.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-close.json
@@ -1,0 +1,36 @@
+{
+  "id" : "bf678e35-677e-33eb-a39f-09187a5ca2ec",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/ingest/7507Q000009f52jQAA",
+    "method" : "PATCH",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\n\t\"state\":\"UploadComplete\"\n}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"7507Q000009f52jQAA\",\"operation\":\"insert\",\"object\":\"Account\",\"createdById\":\"0057Q0000037T8QQAU\",\"createdDate\":\"2023-01-26T10:09:27.000+0000\",\"systemModstamp\":\"2023-01-26T10:09:27.000+0000\",\"state\":\"UploadComplete\",\"concurrencyMode\":\"Parallel\",\"contentType\":\"CSV\",\"apiVersion\":53.0}",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 10:09:47 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=kDU9nJ1hEe2Hsf24L4H7Bw; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 10:09:47 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=26/15000",
+      "Content-Type" : "application/json;charset=UTF-8"
+    }
+  },
+  "uuid" : "bf678e35-677e-33eb-a39f-09187a5ca2ec"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-create.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-create.json
@@ -1,0 +1,37 @@
+{
+  "id" : "fff4fa8f-8bed-3177-adb5-457ea2343861",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/ingest",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\n    \"object\": \"Asset\",\n    \"operation\": \"insert\"\n}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"7507Q000009f52jQAA\",\"operation\":\"insert\",\"object\":\"Asset\",\"createdById\":\"0057Q0000037T8QQAU\",\"createdDate\":\"2023-01-26T09:26:51.000+0000\",\"systemModstamp\":\"2023-01-26T09:26:51.000+0000\",\"state\":\"Open\",\"concurrencyMode\":\"Parallel\",\"contentType\":\"CSV\",\"apiVersion\":53.0,\"contentUrl\":\"services/data/v53.0/jobs/ingest/7507Q000009f4YjQAI/batches\",\"lineEnding\":\"LF\",\"columnDelimiter\":\"COMMA\"}",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 09:26:51 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=kK-sGJ1bEe2dhnlGQfiMlQ; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 09:26:51 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=11/15000",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "fff4fa8f-8bed-3177-adb5-457ea2343861"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-delete.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-delete.json
@@ -1,0 +1,30 @@
+{
+  "id" : "ef68775a-6436-322a-bbdb-9acfa8873e25",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/ingest/7507Q000009f52jQAA",
+    "method" : "DELETE",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 10:11:03 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "Content-Security-Policy" : "upgrade-insecure-requests",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=vWhIp51hEe2I5rWjGWjreg; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 10:11:03 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=28/15000"
+    }
+  },
+  "uuid" : "ef68775a-6436-322a-bbdb-9acfa8873e25"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-get-failed-results.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-get-failed-results.json
@@ -1,0 +1,32 @@
+{
+  "id" : "1c35ea9b-0448-3f06-b92f-1ace789fbfd5",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/ingest/7507Q000009f52jQAA/failedResults",
+    "method" : "GET",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "\"sf__Id\",\"sf__Error\",\"Name\",\"Employees\"\n",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 10:10:23 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=pWYK_51hEe22B2tN6FkXMg; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 10:10:23 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=28/15000",
+      "Content-Type" : "text/csv",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "1c35ea9b-0448-3f06-b92f-1ace789fbfd5"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-get-info.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-get-info.json
@@ -1,0 +1,32 @@
+{
+  "id": "70f0911e-0386-3128-91be-40d4bfbdb336",
+  "request": {
+    "url": "/services/data/v53.0/jobs/ingest/7507Q000009f52jQAA",
+    "method": "GET",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"id\":\"7507Q000009f52jQAA\",\"operation\":\"insert\",\"object\":\"Account\",\"createdById\":\"0057Q0000037T8QQAU\",\"createdDate\":\"2023-01-26T10:09:27.000+0000\",\"systemModstamp\":\"2023-01-26T10:09:49.000+0000\",\"state\":\"Failed\",\"concurrencyMode\":\"Parallel\",\"contentType\":\"CSV\",\"apiVersion\":53.0,\"jobType\":\"V2Ingest\",\"lineEnding\":\"LF\",\"columnDelimiter\":\"COMMA\",\"numberRecordsProcessed\":0,\"numberRecordsFailed\":0,\"retries\":0,\"totalProcessingTime\":0,\"apiActiveProcessingTime\":0,\"apexProcessingTime\":0,\"errorMessage\":\"InvalidBatch : InvalidBatch : Field name not found : Employees\"}",
+    "headers": {
+      "Date": "Thu, 26 Jan 2023 10:10:02 GMT",
+      "Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": "BrowserId=mOcJiJ1hEe2K0PtKPaxCMw; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 10:10:02 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info": "api-usage=27/15000",
+      "Content-Type": "application/json;charset=UTF-8",
+      "Vary": "Accept-Encoding"
+    }
+  },
+  "uuid": "70f0911e-0386-3128-91be-40d4bfbdb336"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-get-successful-results.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-get-successful-results.json
@@ -1,0 +1,32 @@
+{
+  "id" : "9b2b3845-8228-3230-87d9-0d6e6dcd72f3",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/ingest/7507Q000009f52jQAA/successfulResults",
+    "method" : "GET",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "\"sf__Id\",\"sf__Created\",\"Name\",\"Employees\"\n",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 10:10:47 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=tC0nfZ1hEe2W_2v1yoWiTw; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 10:10:47 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=28/15000",
+      "Content-Type" : "text/csv",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "9b2b3845-8228-3230-87d9-0d6e6dcd72f3"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-get-unprocessed-records.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-get-unprocessed-records.json
@@ -1,0 +1,32 @@
+{
+  "id" : "357327b8-f3ff-3308-b568-d01f3a94307d",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/ingest/7507Q000009f52jQAA/unprocessedrecords",
+    "method" : "GET",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "\"Name\",\"Employees\"\n\"Foo\",12\n\"Bar\",1138",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 10:10:39 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=rvuoi51hEe2M6PejSQdc1w; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 10:10:39 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=29/15000",
+      "Content-Type" : "text/csv",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "357327b8-f3ff-3308-b568-d01f3a94307d"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-upload.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-ingest-upload.json
@@ -1,0 +1,35 @@
+{
+  "id": "e9adae44-dce6-343c-bf44-ee2db8fe2881",
+  "request": {
+    "url": "/services/data/v53.0/jobs/ingest/7507Q000009f52jQAA/batches",
+    "method": "PUT",
+    "bodyPatterns": [
+      {
+        "equalTo": "Name,Employees\nFoo,12\nBar,1138\n"
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "Date": "Thu, 26 Jan 2023 10:09:34 GMT",
+      "Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "Content-Security-Policy": "upgrade-insecure-requests",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": "BrowserId=iCtwU51hEe24FT31IRyz7Q; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 10:09:34 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info": "api-usage=26/15000"
+    }
+  },
+  "uuid": "e9adae44-dce6-343c-bf44-ee2db8fe2881"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-create.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-create.json
@@ -1,0 +1,37 @@
+{
+  "id" : "0bf041b6-d516-355f-8726-7abc184b7767",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/query",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\n  \"operation\" : \"query\",\n  \"query\" : \"SELECT Name, Type, Industry FROM Account\",\n  \"contentType\" : \"CSV\",\n  \"columnDelimiter\" : \"COMMA\",\n  \"lineEnding\" : \"LF\"\n} ",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : true
+    } ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"7507Q000009f8jvQAA\",\"operation\":\"query\",\"object\":\"Account\",\"createdById\":\"0057Q0000037T8QQAU\",\"createdDate\":\"2023-01-26T14:50:10.000+0000\",\"systemModstamp\":\"2023-01-26T14:50:10.000+0000\",\"state\":\"UploadComplete\",\"concurrencyMode\":\"Parallel\",\"contentType\":\"CSV\",\"apiVersion\":53.0,\"lineEnding\":\"LF\",\"columnDelimiter\":\"COMMA\"}",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 14:50:10 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=u5BpwZ2IEe2qfyulKSJb5w; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 14:50:10 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=39/15000",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "0bf041b6-d516-355f-8726-7abc184b7767"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-delete.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-delete.json
@@ -1,0 +1,30 @@
+{
+  "id" : "ff1a5e2e-53dc-3ca6-bf09-a8f8e8bd82a6",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/query/7507Q000009f8jvQAA",
+    "method" : "DELETE",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 14:51:08 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "Content-Security-Policy" : "upgrade-insecure-requests",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=3clmY52IEe2p6jGKBJNWpA; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 14:51:08 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=40/15000"
+    }
+  },
+  "uuid" : "ff1a5e2e-53dc-3ca6-bf09-a8f8e8bd82a6"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-get-info.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-get-info.json
@@ -1,0 +1,32 @@
+{
+  "id" : "b6884e47-1388-31e7-9764-8c2f85a5a30a",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/query/7507Q000009f8jvQAA",
+    "method" : "GET",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"7507Q000009f8jvQAA\",\"operation\":\"query\",\"object\":\"Account\",\"createdById\":\"0057Q0000037T8QQAU\",\"createdDate\":\"2023-01-26T14:50:10.000+0000\",\"systemModstamp\":\"2023-01-26T14:50:12.000+0000\",\"state\":\"JobComplete\",\"concurrencyMode\":\"Parallel\",\"contentType\":\"CSV\",\"apiVersion\":53.0,\"jobType\":\"V2Query\",\"lineEnding\":\"LF\",\"columnDelimiter\":\"COMMA\",\"numberRecordsProcessed\":13,\"retries\":0,\"totalProcessingTime\":176}",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 14:50:25 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=xCxkzJ2IEe2eRy_ixvE36A; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 14:50:25 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=40/15000",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "b6884e47-1388-31e7-9764-8c2f85a5a30a"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-get-results-limited-next.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-get-results-limited-next.json
@@ -1,0 +1,34 @@
+{
+  "id" : "56e88479-d4aa-32b2-aad9-1276f891096e",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/query/7507Q000009f9tHQAQ/results?locator=MTA",
+    "method" : "GET",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "\"Name\",\"Type\",\"Industry\"\n\"United Oil & Gas, Singapore\",\"Customer - Direct\",\"Energy\"\n\"GenePoint\",\"Customer - Channel\",\"Biotechnology\"\n\"sForce\",\"\",\"\"\n",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 15:42:32 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=DCNhZ52QEe2Ap6n2c6wPXQ; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 15:42:32 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=37/15000",
+      "Content-Type" : "text/csv",
+      "Sforce-Locator" : "null",
+      "Sforce-NumberOfRecords" : "3",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "56e88479-d4aa-32b2-aad9-1276f891096e"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-get-results-limited.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-get-results-limited.json
@@ -1,0 +1,34 @@
+{
+  "id" : "b3304060-6643-31e9-abe0-db222d9e172a",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/query/7507Q000009f9tHQAQ/results?maxRecords=10",
+    "method" : "GET",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "\"Name\",\"Type\",\"Industry\"\n\"Beispielaccount für Ansprüche\",\"\",\"\"\n\"Edge Communications\",\"Customer - Direct\",\"Electronics\"\n\"Burlington Textiles Corp of America\",\"Customer - Direct\",\"Apparel\"\n\"Pyramid Construction Inc.\",\"Customer - Channel\",\"Construction\"\n\"Dickenson plc\",\"Customer - Channel\",\"Consulting\"\n\"Grand Hotels & Resorts Ltd\",\"Customer - Direct\",\"Hospitality\"\n\"United Oil & Gas Corp.\",\"Customer - Direct\",\"Energy\"\n\"Express Logistics and Transport\",\"Customer - Channel\",\"Transportation\"\n\"University of Arizona\",\"Customer - Direct\",\"Education\"\n\"United Oil & Gas, UK\",\"Customer - Direct\",\"Energy\"\n",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 15:42:06 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=_IkWLZ2PEe2OuyVu6yTLnA; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 15:42:06 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=37/15000",
+      "Content-Type" : "text/csv",
+      "Sforce-Locator" : "MTA",
+      "Sforce-NumberOfRecords" : "10",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "b3304060-6643-31e9-abe0-db222d9e172a"
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-get-results.json
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/resources/mappings/bulk-query-get-results.json
@@ -1,0 +1,34 @@
+{
+  "id" : "4c269313-e0d3-3750-bed7-8b998f2cdb97",
+  "request" : {
+    "url" : "/services/data/v53.0/jobs/query/7507Q000009f8jvQAA/results",
+    "method" : "GET",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-java-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "\"Name\",\"Type\",\"Industry\"\n\"Beispielaccount für Ansprüche\",\"\",\"\"\n\"Edge Communications\",\"Customer - Direct\",\"Electronics\"\n\"Burlington Textiles Corp of America\",\"Customer - Direct\",\"Apparel\"\n\"Pyramid Construction Inc.\",\"Customer - Channel\",\"Construction\"\n\"Dickenson plc\",\"Customer - Channel\",\"Consulting\"\n\"Grand Hotels & Resorts Ltd\",\"Customer - Direct\",\"Hospitality\"\n\"United Oil & Gas Corp.\",\"Customer - Direct\",\"Energy\"\n\"Express Logistics and Transport\",\"Customer - Channel\",\"Transportation\"\n\"University of Arizona\",\"Customer - Direct\",\"Education\"\n\"United Oil & Gas, UK\",\"Customer - Direct\",\"Energy\"\n\"United Oil & Gas, Singapore\",\"Customer - Direct\",\"Energy\"\n\"GenePoint\",\"Customer - Channel\",\"Biotechnology\"\n\"sForce\",\"\",\"\"\n",
+    "headers" : {
+      "Date" : "Thu, 26 Jan 2023 14:50:34 GMT",
+      "Strict-Transport-Security" : "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options" : "nosniff",
+      "X-XSS-Protection" : "1; mode=block",
+      "X-Robots-Tag" : "none",
+      "Cache-Control" : "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie" : "BrowserId=ydmkFJ2IEe2qeWljrtQmBw; domain=.salesforce.com; path=/; expires=Fri, 26-Jan-2024 14:50:34 GMT; Max-Age=31536000",
+      "Sforce-Limit-Info" : "api-usage=40/15000",
+      "Content-Type" : "text/csv",
+      "Sforce-Locator" : "null",
+      "Sforce-NumberOfRecords" : "13",
+      "Vary" : "Accept-Encoding"
+    }
+  },
+  "uuid" : "4c269313-e0d3-3750-bed7-8b998f2cdb97"
+}


### PR DESCRIPTION
Adds `RestApiRequest` implementations for bulk queries and ingests. These will be used to implement the next major SDK version that provides bulk API support. Please note that this PR only changes the shared Rest API module and does not provide a way for users to actually use the bulk API. This will be implemented in a later PR that builds on-top of this one.

Ref: GUS-W-12340021