### PR TITLE
Generalize `RestApi` body types

### DIFF
--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
@@ -7,18 +7,7 @@
 package com.salesforce.functions.jvm.runtime.sdk;
 
 import com.google.gson.JsonElement;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.CompositeGraphRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.CreateRecordRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.DeleteRecordRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryNextRecordsRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryRecordRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryRecordResult;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.UpdateRecordRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
 import com.salesforce.functions.jvm.sdk.data.DataApi;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import com.salesforce.functions.jvm.sdk.data.RecordModificationResult;
@@ -52,7 +41,7 @@ public class DataApiImpl implements DataApi {
   @Override
   @Nonnull
   public RecordQueryResult query(String soql) throws DataApiException {
-    RestApiRequest<QueryRecordResult> request = new QueryRecordRestApiRequest(soql);
+    JsonRestApiRequest<QueryRecordResult> request = new QueryRecordRestApiRequest(soql);
 
     try {
       return BinaryFieldUtil.convert(executeRequest(request), restApi);
@@ -154,7 +143,7 @@ public class DataApiImpl implements DataApi {
     return restApi.getAccessToken();
   }
 
-  public static RestApiRequest<ModifyRecordResult> apiRequestForUpdate(Record record) {
+  public static JsonRestApiRequest<ModifyRecordResult> apiRequestForUpdate(Record record) {
     if (!(record instanceof RecordImpl)) {
       throw new IllegalArgumentException(INCOMPATIBLE_RECORD_MESSAGE);
     }
@@ -175,7 +164,7 @@ public class DataApiImpl implements DataApi {
     return new UpdateRecordRestApiRequest(id, recordImpl.getType(), fieldValues);
   }
 
-  public static RestApiRequest<ModifyRecordResult> apiRequestForCreate(Record record) {
+  public static JsonRestApiRequest<ModifyRecordResult> apiRequestForCreate(Record record) {
     if (!(record instanceof RecordImpl)) {
       throw new IllegalArgumentException(INCOMPATIBLE_RECORD_MESSAGE);
     }
@@ -185,7 +174,7 @@ public class DataApiImpl implements DataApi {
         recordImpl.getType(), BinaryFieldUtil.convert(recordImpl.getFieldValues()));
   }
 
-  private <T> T executeRequest(RestApiRequest<T> request) throws DataApiException {
+  private <T> T executeRequest(JsonRestApiRequest<T> request) throws DataApiException {
     try {
       return restApi.execute(request);
     } catch (RestApiErrorsException restApiException) {

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkBuilderImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkBuilderImpl.java
@@ -7,8 +7,8 @@
 package com.salesforce.functions.jvm.runtime.sdk;
 
 import com.salesforce.functions.jvm.runtime.sdk.restapi.DeleteRecordRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.JsonRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiRequest;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import com.salesforce.functions.jvm.sdk.data.ReferenceId;
 import com.salesforce.functions.jvm.sdk.data.UnitOfWork;
@@ -20,7 +20,7 @@ import javax.annotation.Nonnull;
 public class UnitOfWorkBuilderImpl implements UnitOfWorkBuilder {
   // Order is important, don't replace LinkedHashMap without verifying the new implementation
   // also preserves insertion order!
-  private final LinkedHashMap<String, RestApiRequest<ModifyRecordResult>> subrequests =
+  private final LinkedHashMap<String, JsonRestApiRequest<ModifyRecordResult>> subrequests =
       new LinkedHashMap<>();
 
   private final AtomicInteger nextReferenceId = new AtomicInteger(0);

--- a/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkImpl.java
@@ -6,8 +6,8 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
+import com.salesforce.functions.jvm.runtime.sdk.restapi.JsonRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiRequest;
 import com.salesforce.functions.jvm.sdk.data.UnitOfWork;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -16,13 +16,13 @@ import java.util.Map;
 public class UnitOfWorkImpl implements UnitOfWork {
   // Order is important, don't replace LinkedHashMap without verifying the new implementation
   // also preserves insertion order!
-  private final LinkedHashMap<String, RestApiRequest<ModifyRecordResult>> subrequests;
+  private final LinkedHashMap<String, JsonRestApiRequest<ModifyRecordResult>> subrequests;
 
-  public UnitOfWorkImpl(LinkedHashMap<String, RestApiRequest<ModifyRecordResult>> subrequests) {
+  public UnitOfWorkImpl(LinkedHashMap<String, JsonRestApiRequest<ModifyRecordResult>> subrequests) {
     this.subrequests = subrequests;
   }
 
-  public Map<String, RestApiRequest<ModifyRecordResult>> getSubrequests() {
+  public Map<String, JsonRestApiRequest<ModifyRecordResult>> getSubrequests() {
     return Collections.unmodifiableMap(subrequests);
   }
 }

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java
@@ -7,18 +7,7 @@
 package com.salesforce.functions.jvm.runtime.sdk;
 
 import com.google.gson.JsonElement;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.CompositeGraphRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.CreateRecordRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.DeleteRecordRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryNextRecordsRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryRecordRestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.QueryRecordResult;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApi;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiErrorsException;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiException;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiRequest;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.UpdateRecordRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.*;
 import com.salesforce.functions.jvm.sdk.data.DataApi;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import com.salesforce.functions.jvm.sdk.data.RecordModificationResult;
@@ -52,7 +41,7 @@ public class DataApiImpl implements DataApi {
   @Override
   @Nonnull
   public RecordQueryResult query(String soql) throws DataApiException {
-    RestApiRequest<QueryRecordResult> request = new QueryRecordRestApiRequest(soql);
+    JsonRestApiRequest<QueryRecordResult> request = new QueryRecordRestApiRequest(soql);
 
     return new RecordQueryResultImpl(executeRequest(request));
   }
@@ -145,7 +134,7 @@ public class DataApiImpl implements DataApi {
     return restApi.getAccessToken();
   }
 
-  public static RestApiRequest<ModifyRecordResult> apiRequestForUpdate(Record record) {
+  public static JsonRestApiRequest<ModifyRecordResult> apiRequestForUpdate(Record record) {
     if (!(record instanceof RecordImpl)) {
       throw new IllegalArgumentException(INCOMPATIBLE_RECORD_MESSAGE);
     }
@@ -167,7 +156,7 @@ public class DataApiImpl implements DataApi {
     return new UpdateRecordRestApiRequest(id, recordImpl.getType(), fieldValues);
   }
 
-  public static RestApiRequest<ModifyRecordResult> apiRequestForCreate(Record record) {
+  public static JsonRestApiRequest<ModifyRecordResult> apiRequestForCreate(Record record) {
     if (!(record instanceof RecordImpl)) {
       throw new IllegalArgumentException(INCOMPATIBLE_RECORD_MESSAGE);
     }
@@ -177,7 +166,7 @@ public class DataApiImpl implements DataApi {
     return new CreateRecordRestApiRequest(recordImpl.getType(), recordImpl.getFieldValues());
   }
 
-  private <T> T executeRequest(RestApiRequest<T> request) throws DataApiException {
+  private <T> T executeRequest(JsonRestApiRequest<T> request) throws DataApiException {
     try {
       return restApi.execute(request);
     } catch (RestApiErrorsException restApiException) {

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkBuilderImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkBuilderImpl.java
@@ -7,8 +7,8 @@
 package com.salesforce.functions.jvm.runtime.sdk;
 
 import com.salesforce.functions.jvm.runtime.sdk.restapi.DeleteRecordRestApiRequest;
+import com.salesforce.functions.jvm.runtime.sdk.restapi.JsonRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiRequest;
 import com.salesforce.functions.jvm.sdk.data.Record;
 import com.salesforce.functions.jvm.sdk.data.ReferenceId;
 import com.salesforce.functions.jvm.sdk.data.UnitOfWork;
@@ -20,7 +20,7 @@ import javax.annotation.Nonnull;
 public class UnitOfWorkBuilderImpl implements UnitOfWorkBuilder {
   // Order is important, don't replace LinkedHashMap without verifying the new implementation
   // also preserves insertion order!
-  private final LinkedHashMap<String, RestApiRequest<ModifyRecordResult>> subrequests =
+  private final LinkedHashMap<String, JsonRestApiRequest<ModifyRecordResult>> subrequests =
       new LinkedHashMap<>();
 
   private final AtomicInteger nextReferenceId = new AtomicInteger(0);

--- a/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkImpl.java
+++ b/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/UnitOfWorkImpl.java
@@ -6,8 +6,8 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk;
 
+import com.salesforce.functions.jvm.runtime.sdk.restapi.JsonRestApiRequest;
 import com.salesforce.functions.jvm.runtime.sdk.restapi.ModifyRecordResult;
-import com.salesforce.functions.jvm.runtime.sdk.restapi.RestApiRequest;
 import com.salesforce.functions.jvm.sdk.data.UnitOfWork;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -16,13 +16,13 @@ import java.util.Map;
 public class UnitOfWorkImpl implements UnitOfWork {
   // Order is important, don't replace LinkedHashMap without verifying the new implementation
   // also preserves insertion order!
-  private final LinkedHashMap<String, RestApiRequest<ModifyRecordResult>> subrequests;
+  private final LinkedHashMap<String, JsonRestApiRequest<ModifyRecordResult>> subrequests;
 
-  public UnitOfWorkImpl(LinkedHashMap<String, RestApiRequest<ModifyRecordResult>> subrequests) {
+  public UnitOfWorkImpl(LinkedHashMap<String, JsonRestApiRequest<ModifyRecordResult>> subrequests) {
     this.subrequests = subrequests;
   }
 
-  public Map<String, RestApiRequest<ModifyRecordResult>> getSubrequests() {
+  public Map<String, JsonRestApiRequest<ModifyRecordResult>> getSubrequests() {
     return Collections.unmodifiableMap(subrequests);
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/AbstractQueryRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/AbstractQueryRestApiRequest.java
@@ -16,17 +16,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class AbstractQueryRestApiRequest implements RestApiRequest<QueryRecordResult> {
+public abstract class AbstractQueryRestApiRequest extends JsonRestApiRequest<QueryRecordResult> {
   private final Gson gson = new Gson();
 
   @Override
   public final QueryRecordResult processResponse(
-      int statusCode, Map<String, String> headers, JsonElement json) throws RestApiErrorsException {
+      int statusCode, Map<String, String> headers, JsonElement jsonRequestBody)
+      throws RestApiErrorsException {
 
     if (statusCode != 200) {
-      throw new RestApiErrorsException(ErrorResponseParser.parse(json));
+      throw new RestApiErrorsException(ErrorResponseParser.parse(jsonRequestBody));
     } else {
-      return parseQueryResult(json.getAsJsonObject());
+      return parseQueryResult(jsonRequestBody.getAsJsonObject());
     }
   }
 

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/BodyParsingException.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/BodyParsingException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+public class BodyParsingException extends Exception {
+  public BodyParsingException() {
+    super();
+  }
+
+  public BodyParsingException(String message) {
+    super(message);
+  }
+
+  public BodyParsingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public BodyParsingException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/CreateRecordRestApiRequest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.http.client.utils.URIBuilder;
 
-public class CreateRecordRestApiRequest implements RestApiRequest<ModifyRecordResult> {
+public class CreateRecordRestApiRequest extends JsonRestApiRequest<ModifyRecordResult> {
   private final String type;
   private final Map<String, JsonElement> values;
 
@@ -36,17 +36,18 @@ public class CreateRecordRestApiRequest implements RestApiRequest<ModifyRecordRe
   }
 
   @Override
-  public Optional<JsonElement> getBody() {
-    return Optional.of(new Gson().toJsonTree(values));
+  public Optional<JsonRequestBody> getBody() {
+    return Optional.of(new JsonRequestBody(new Gson().toJsonTree(values)));
   }
 
   @Override
   public ModifyRecordResult processResponse(
-      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+      int statusCode, Map<String, String> headers, JsonElement jsonRequestBody)
+      throws RestApiErrorsException {
     if (statusCode == 201) {
-      return new ModifyRecordResult(body.getAsJsonObject().get("id").getAsString());
+      return new ModifyRecordResult(jsonRequestBody.getAsJsonObject().get("id").getAsString());
     } else {
-      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+      throw new RestApiErrorsException(ErrorResponseParser.parse(jsonRequestBody));
     }
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/DeleteRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/DeleteRecordRestApiRequest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.http.client.utils.URIBuilder;
 
-public class DeleteRecordRestApiRequest implements RestApiRequest<ModifyRecordResult> {
+public class DeleteRecordRestApiRequest extends JsonRestApiRequest<ModifyRecordResult> {
   private final String type;
   private final String id;
 
@@ -35,17 +35,18 @@ public class DeleteRecordRestApiRequest implements RestApiRequest<ModifyRecordRe
   }
 
   @Override
-  public Optional<JsonElement> getBody() {
+  public Optional<JsonRequestBody> getBody() {
     return Optional.empty();
   }
 
   @Override
   public ModifyRecordResult processResponse(
-      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+      int statusCode, Map<String, String> headers, JsonElement jsonRequestBody)
+      throws RestApiErrorsException {
     if (statusCode == 204) {
       return new ModifyRecordResult(id);
     } else {
-      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+      throw new RestApiErrorsException(ErrorResponseParser.parse(jsonRequestBody));
     }
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/JsonRequestBody.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/JsonRequestBody.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.entity.ContentType;
+
+public class JsonRequestBody implements RestApiRequestBody {
+  private final JsonElement jsonElement;
+
+  public JsonRequestBody(JsonElement jsonElement) {
+    this.jsonElement = jsonElement;
+  }
+
+  public JsonElement getJsonElement() {
+    return jsonElement;
+  }
+
+  @Override
+  public ContentType getContentType() {
+    return ContentType.APPLICATION_JSON;
+  }
+
+  @Override
+  public byte[] getRequestContents() {
+    return new Gson().toJson(this.jsonElement).getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/JsonRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/JsonRestApiRequest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+
+public abstract class JsonRestApiRequest<T>
+    implements RestApiRequest<T, JsonRequestBody, JsonElement> {
+  @Override
+  public JsonElement parseBody(byte[] body) throws BodyParsingException {
+    try {
+      return new Gson()
+          .fromJson(new InputStreamReader(new ByteArrayInputStream(body)), JsonElement.class);
+    } catch (JsonSyntaxException e) {
+      throw new BodyParsingException(e);
+    }
+  }
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryNextRecordsRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryNextRecordsRestApiRequest.java
@@ -6,7 +6,6 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
-import com.google.gson.JsonElement;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
@@ -30,7 +29,7 @@ public class QueryNextRecordsRestApiRequest extends AbstractQueryRestApiRequest 
   }
 
   @Override
-  public Optional<JsonElement> getBody() {
+  public Optional<JsonRequestBody> getBody() {
     return Optional.empty();
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/QueryRecordRestApiRequest.java
@@ -6,7 +6,6 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
-import com.google.gson.JsonElement;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
@@ -33,7 +32,7 @@ public class QueryRecordRestApiRequest extends AbstractQueryRestApiRequest {
   }
 
   @Override
-  public Optional<JsonElement> getBody() {
+  public Optional<JsonRequestBody> getBody() {
     return Optional.empty();
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiRequest.java
@@ -6,19 +6,20 @@
  */
 package com.salesforce.functions.jvm.runtime.sdk.restapi;
 
-import com.google.gson.JsonElement;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Optional;
 
-public interface RestApiRequest<T> {
+public interface RestApiRequest<T, A extends RestApiRequestBody, B> {
   HttpMethod getHttpMethod();
 
   URI createUri(URI baseUri, String apiVersion) throws URISyntaxException;
 
-  Optional<JsonElement> getBody();
+  Optional<A> getBody();
 
-  T processResponse(int statusCode, Map<String, String> headers, JsonElement body)
+  T processResponse(int statusCode, Map<String, String> headers, B body)
       throws RestApiErrorsException;
+
+  B parseBody(byte[] body) throws BodyParsingException;
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiRequestBody.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiRequestBody.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.functions.jvm.runtime.sdk.restapi;
+
+import org.apache.http.entity.ContentType;
+
+public interface RestApiRequestBody {
+  ContentType getContentType();
+
+  byte[] getRequestContents();
+}

--- a/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/UpdateRecordRestApiRequest.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.http.client.utils.URIBuilder;
 
-public class UpdateRecordRestApiRequest implements RestApiRequest<ModifyRecordResult> {
+public class UpdateRecordRestApiRequest extends JsonRestApiRequest<ModifyRecordResult> {
   private final String id;
   private final String type;
   private final Map<String, JsonElement> values;
@@ -39,17 +39,18 @@ public class UpdateRecordRestApiRequest implements RestApiRequest<ModifyRecordRe
   }
 
   @Override
-  public Optional<JsonElement> getBody() {
-    return Optional.of(new Gson().toJsonTree(values));
+  public Optional<JsonRequestBody> getBody() {
+    return Optional.of(new JsonRequestBody(new Gson().toJsonTree(values)));
   }
 
   @Override
   public ModifyRecordResult processResponse(
-      int statusCode, Map<String, String> headers, JsonElement body) throws RestApiErrorsException {
+      int statusCode, Map<String, String> headers, JsonElement jsonRequestBody)
+      throws RestApiErrorsException {
     if (statusCode == 204) {
       return new ModifyRecordResult(id);
     } else {
-      throw new RestApiErrorsException(ErrorResponseParser.parse(body));
+      throw new RestApiErrorsException(ErrorResponseParser.parse(jsonRequestBody));
     }
   }
 }

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
@@ -35,7 +35,7 @@ public class RestApiCompositeTest {
 
   @Test
   public void compositeSingleCreate() throws RestApiErrorsException, IOException, RestApiException {
-    Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
+    Map<String, JsonRestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
 
     Map<String, JsonElement> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Star Wars Episode IV - A New Hope"));
@@ -54,7 +54,7 @@ public class RestApiCompositeTest {
 
   @Test
   public void compositeSingleCreateWithError() throws IOException, RestApiException {
-    Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
+    Map<String, JsonRestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
 
     Map<String, JsonElement> values = new HashMap<>();
     values.put("Name", new JsonPrimitive("Star Wars Episode IV - A New Hope"));
@@ -84,7 +84,7 @@ public class RestApiCompositeTest {
 
   @Test
   public void compositeSingleUpdate() throws RestApiErrorsException, IOException, RestApiException {
-    Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
+    Map<String, JsonRestApiRequest<ModifyRecordResult>> subrequests = new HashMap<>();
 
     Map<String, JsonElement> values = new HashMap<>();
     values.put("ReleaseDate__c", new JsonPrimitive("1980-05-21"));
@@ -103,7 +103,7 @@ public class RestApiCompositeTest {
 
   @Test
   public void compositeCreateTree() throws RestApiErrorsException, IOException, RestApiException {
-    Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new LinkedHashMap<>();
+    Map<String, JsonRestApiRequest<ModifyRecordResult>> subrequests = new LinkedHashMap<>();
 
     Map<String, JsonElement> valuesFranchise = new HashMap<>();
     valuesFranchise.put("Name", new JsonPrimitive("Star Wars"));
@@ -149,7 +149,7 @@ public class RestApiCompositeTest {
 
   @Test
   public void compositeDeleteTest() throws RestApiErrorsException, IOException, RestApiException {
-    Map<String, RestApiRequest<ModifyRecordResult>> subrequests = new LinkedHashMap<>();
+    Map<String, JsonRestApiRequest<ModifyRecordResult>> subrequests = new LinkedHashMap<>();
     subrequests.put(
         "referenceId0", new DeleteRecordRestApiRequest("Movie__c", "a01B0000009gSr9IAE"));
 

--- a/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
+++ b/sf-fx-runtime-java-sdk-rest-api/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiTest.java
@@ -35,7 +35,7 @@ public class RestApiTest {
     try {
       restApi.execute(queryRequest);
     } catch (RestApiException e) {
-      assertThat(e.getMessage(), startsWith("Could not parse API response as JSON!"));
+      assertThat(e.getMessage(), startsWith("Could not parse API response!"));
 
       return;
     }


### PR DESCRIPTION
Add support for non-JSON body types to `RestApi`, the underlying module for SDK implementations. This is a prerequisite for Bulk API support which has CSV body types for both incoming and outgoing requests. Since JSON bodies are still the most common case, helpers have been added that keep implementing JSON requests straightforward (`JsonRestApiRequest`).

Ref: GUS-W-12340021
