### PR TITLE
Added support for 1.1.2 of Java SDK

### DIFF
--- a/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
+++ b/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/sfjavafunction/SalesforceFunctionsProjectFunctionsScanner.java
@@ -451,6 +451,7 @@ public class SalesforceFunctionsProjectFunctionsScanner
     mapping.put("1.0.0", "sdk-impl-v1.jar");
     mapping.put("1.1.0", "sdk-impl-v1.1.jar");
     mapping.put("1.1.1", "sdk-impl-v1.1.jar");
+    mapping.put("1.1.2", "sdk-impl-v1.1.jar");
 
     return Optional.ofNullable(properties.getProperty("version"))
         .flatMap((version) -> Optional.ofNullable(mapping.get(version)));

--- a/sf-fx-runtime-java-sdk-impl-v1.1/pom.xml
+++ b/sf-fx-runtime-java-sdk-impl-v1.1/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.salesforce.functions</groupId>
       <artifactId>sf-fx-sdk-java</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Adds an entry for version 1.1.2 of the SDK so that the runtime knows how to map to that version. 

[GUS-W-13579117](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13579117)