### PR TITLE
Dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Undertow 2.3 only supports JDK 11 - https://issues.redhat.com/browse/UNDERTOW-2049
+      - dependency-name: "io.undertow:undertow-core"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/sf-fx-runtime-java-runtime/pom.xml
+++ b/sf-fx-runtime-java-runtime/pom.xml
@@ -19,7 +19,7 @@
     <undertow.version>2.2.32.Final</undertow.version>
     <picocli.version>4.7.5</picocli.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.2.13</logback.version>
     <tomlj.version>1.1.1</tomlj.version>
   </properties>
 


### PR DESCRIPTION
- Added `io.undertow:undertow-core` to the ignore list for dependency updates since version 2.3 only supports JDK 11
- Updated `ch.qos.logback:logback-classic`

Closes #471